### PR TITLE
missing username and password for mssql

### DIFF
--- a/generators/app/templates/service.js
+++ b/generators/app/templates/service.js
@@ -13,12 +13,12 @@ module.exports = function() {
     storage: app.get('sqlite'),
     logging: false
   });<% } else if (database === 'mssql') { %>
-  const sequelize = new Sequelize('feathers', {
+  const sequelize = new Sequelize('feathers', 'username', 'password', {
     dialect: '<%= database %>',
     host: 'localhost',
-    port: 1433,
     logging: false,
     dialectOptions: {
+      port: 1433,
       instanceName: 'feathers'
     }
   });<% } else if (database === 'postgres' || database === 'mysql' || database === 'mariadb') { %>


### PR DESCRIPTION
according to Sequelize class, second and third parameter should be the username and password followed by the options.
the port is passed to tedious via dialectOptions