### PR TITLE
mssql to make use of config/*.json connection string

### DIFF
--- a/generators/app/templates/service.js
+++ b/generators/app/templates/service.js
@@ -12,16 +12,7 @@ module.exports = function() {
     dialect: 'sqlite',
     storage: app.get('sqlite'),
     logging: false
-  });<% } else if (database === 'mssql') { %>
-  const sequelize = new Sequelize('feathers', {
-    dialect: '<%= database %>',
-    host: 'localhost',
-    port: 1433,
-    logging: false,
-    dialectOptions: {
-      instanceName: 'feathers'
-    }
-  });<% } else if (database === 'postgres' || database === 'mysql' || database === 'mariadb') { %>
+  });<% } else if (database === 'postgres' || database === 'mysql' || database === 'mariadb' || database === 'mssql') { %>
   const sequelize = new Sequelize(app.get('<%= database %>'), {
     dialect: '<%= database %>',
     logging: false


### PR DESCRIPTION
according to sequelize docs, mssql accepts a connection string just like mysql/pg
http://docs.sequelizejs.com/en/latest/docs/getting-started/#setting-up-a-connection

for instance, the generator does generate the connection string under config/default.json
```
"mssql": "mssql://root:@localhost:1433/test",
```
but it's not being used anywhere since it was being hard coded under /src/services/index.js