### PR TITLE
Addng an update prompt when any generators are invoked

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -3,11 +3,18 @@
 var generators = require('yeoman-generator');
 var path = require('path');
 var crypto = require('crypto');
+var updateMixin = require('../../lib/updateMixin');
 var S = require('string');
 var AUTH_PROVIDERS = require('./auth-mapping.json');
 
 module.exports = generators.Base.extend({
+  constructor: function() {
+    generators.Base.apply(this, arguments);
+    updateMixin.extend(this);
+  },
+  
   initializing: function () {
+    var done = this.async();
     this.pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
     this.props = {
       name: process.cwd().split(path.sep).pop(),
@@ -22,6 +29,7 @@ module.exports = generators.Base.extend({
       'compression',
       'winston'
     ];
+    this.mixins.notifyUpdate(done);
   },
 
   prompting: function () {

--- a/generators/hook/index.js
+++ b/generators/hook/index.js
@@ -5,6 +5,7 @@ var path = require('path');
 var fs = require('fs');
 var inflect = require('i')();
 var transform = require('../../lib/transform');
+var updateMixin = require('../../lib/updateMixin');
 
 function importHook(filename, name, moduleName, type, methods) {
   // Lookup existing services/<service-name>/hooks/index.js file
@@ -22,10 +23,17 @@ function importHook(filename, name, moduleName, type, methods) {
 }
 
 module.exports = generators.Base.extend({
+  constructor: function() {
+    generators.Base.apply(this, arguments);
+    updateMixin.extend(this);
+  },
+  
   initializing: function (name) {
+    var done = this.async();
     this.props = {
       name: name
     };
+    this.mixins.notifyUpdate(done);
   },
 
   prompting: function () {

--- a/generators/middleware/index.js
+++ b/generators/middleware/index.js
@@ -1,6 +1,7 @@
 var generators = require('yeoman-generator');
 var fs = require('fs');
 var inflect = require('i')();
+var updateMixin = require('../../lib/updateMixin');
 
 function importMiddleware(filename, name, module) {
   // Lookup existing service/index.js file
@@ -20,10 +21,17 @@ function importMiddleware(filename, name, module) {
 }
 
 module.exports = generators.Base.extend({
+  constructor: function() {
+    generators.Base.apply(this, arguments);
+    updateMixin.extend(this);
+  },
+  
   initializing: function (name) {
+    var done = this.async();
     this.props = { name: name };
 
     this.props = Object.assign(this.props, this.options);
+    this.mixins.notifyUpdate(done);
   },
 
   prompting: function () {

--- a/generators/model/index.js
+++ b/generators/model/index.js
@@ -1,15 +1,23 @@
 'use strict';
 
 var generators = require('yeoman-generator');
+var updateMixin = require('../../lib/updateMixin');
 
 module.exports = generators.Base.extend({
+  constructor: function() {
+    generators.Base.apply(this, arguments);
+    updateMixin.extend(this);
+  },
+  
   initializing: function (name) {
+    var done = this.async();
     this.props = {
       name: name,
       type: 'generic'
     };
 
     this.props = Object.assign(this.props, this.options);
+    this.mixins.notifyUpdate(done);
   },
 
   prompting: function () {

--- a/generators/service/index.js
+++ b/generators/service/index.js
@@ -2,6 +2,7 @@ var generators = require('yeoman-generator');
 var fs = require('fs');
 var inflect = require('i')();
 var transform = require('../../lib/transform');
+var updateMixin = require('../../lib/updateMixin');
 
 function importService(filename, name, moduleName) {
   // Lookup existing service/index.js file
@@ -17,10 +18,17 @@ function importService(filename, name, moduleName) {
 }
 
 module.exports = generators.Base.extend({
+  constructor: function() {
+    generators.Base.apply(this, arguments);
+    updateMixin.extend(this);
+  },
+  
   initializing: function (name) {
+    var done = this.async();
     this.props = { name: name, authentication: false };
 
     this.props = Object.assign(this.props, this.options);
+    this.mixins.notifyUpdate(done);
   },
 
   prompting: function () {

--- a/lib/updateMixin.js
+++ b/lib/updateMixin.js
@@ -1,0 +1,92 @@
+'use strict';
+var updateNotifier = require('update-notifier');
+var chalk = require('chalk');
+var stringLength = require('string-length');
+var repeating = require('repeating');
+var spawn = require('cross-spawn-async');
+var pkg = require('../package.json');
+/**
+ * Generates the message to display when a new update is available
+ * @param  {Object} update - The update object coming from update-notifier
+ * @returns {String}        - The message to display
+ */
+var makeMessage = function(update) {
+    var line1 = ' Update available: ' + chalk.green.bold(update.latest) +
+        chalk.dim(' (current: ' + update.current + ')') + ' ';
+    var line2 = ' Run ' + chalk.blue('npm install -g ' + update.name) +
+        ' to update. ';
+    var contentWidth = Math.max(stringLength(line1), stringLength(line2));
+    var line1rest = contentWidth - stringLength(line1);
+    var line2rest = contentWidth - stringLength(line2);
+    var top = chalk.yellow('┌' + repeating('─', contentWidth) + '┐');
+    var bottom = chalk.yellow('└' + repeating('─', contentWidth) + '┘');
+    var side = chalk.yellow('│');
+
+    var message =
+        '\n' +
+        top + '\n' +
+        side + line1 + repeating(' ', line1rest) + side + '\n' +
+        side + line2 + repeating(' ', line2rest) + side + '\n' +
+        bottom + '\n';
+    return message;
+};
+
+/**
+ * Notify if the generator should be updated
+ * @param {Function} cb - The callback function
+ */
+var notifyUpdate = function(cb) {
+    updateNotifier({
+        pkg: pkg,
+        callback: function(error, update) {
+            if (error) {
+                cb();
+                return;
+            }
+            if (update.latest !== update.current) {
+                var message = makeMessage(update);
+                this.log(message);
+                var prompts = [{
+                  name: 'updateGenerator',
+                  type: 'list',
+                  message: 'Do you want to update this generator?',
+                  choices: [
+                    {
+                      name: 'Yes (stops the generator and runs npm install -g generator-feathers)',
+                      value: 'yes'
+                    },
+                    {
+                      name: 'No (continues running the generator)',
+                      value: 'no'
+                    },
+                    {
+                      name: 'Get me out of here',
+                      value: 'leave'
+                    }
+                  ]
+                }];
+                this.prompt(prompts, function (props) {
+                  if(props.updateGenerator === 'yes') {
+                    spawn('npm', ['install', '-g', '--dry-run', 'generator-feathers'], {stdio: 'inherit'})
+                      .on('close', function(){
+                        process.exit();
+                      });
+                  } else if (props.updateGenerator === 'leave') {
+                    process.exit();
+                  } else {
+                    cb();
+                  }
+                }.bind(this));
+            } else {
+                cb();
+            }
+        }.bind(this)
+    });
+};
+
+module.exports = {
+    extend: function(generator) {
+        var mixins = generator.mixins = generator.mixins || {};
+        mixins.notifyUpdate = notifyUpdate.bind(generator);
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generator-feathers",
   "description": "A Yeoman generator for a Feathers application",
-  "version": "0.6.10",
+  "version": "0.5.9",
   "homepage": "https://github.com/feathersjs/generator-feathers",
   "main": "generators/app/index.js",
   "license": "MIT",
@@ -53,6 +53,8 @@
     "i": "^0.3.3",
     "recast": "^0.11.2",
     "string": "^3.3.1",
+    "string-length": "^1.0.1",
+    "update-notifier": "^0.6.1",
     "yeoman-generator": "^0.21.1"
   },
   "devDependencies": {


### PR DESCRIPTION
So here's an attempt at fixing #63. It uses `[update-notifier](https://github.com/yeoman/update-notifier)` which pretty much every CLI tool uses for this sort of thing.

Here's what it looks like:
![feathers-generator-update](https://cloud.githubusercontent.com/assets/464282/13627578/5a92dc3e-e599-11e5-981c-0ff89035d5f4.gif)

If there is an update, the user gets a prompt where they have 3 choices:

- they can have us invoke the command to install the update
- they can decline and continue with the generator
- they can exit the process

By default `update-notifier` will run at most weekly.