### PR TITLE
Removing the dry-run arg so the update script actually updates

### DIFF
--- a/lib/updateMixin.js
+++ b/lib/updateMixin.js
@@ -67,7 +67,7 @@ var notifyUpdate = function(cb) {
                 }];
                 this.prompt(prompts, function (props) {
                   if(props.updateGenerator === 'yes') {
-                    spawn('npm', ['install', '-g', '--dry-run', 'generator-feathers'], {stdio: 'inherit'})
+                    spawn('npm', ['install', '-g', 'generator-feathers'], {stdio: 'inherit'})
                       .on('close', function(){
                         process.exit();
                       });


### PR DESCRIPTION
I just noticed that I left a `--dry-run` flag in the update script. This removes that so the script actually updates the generator.