### PR TITLE
jslint error in authentication

### DIFF
--- a/generators/app/templates/authentication.js
+++ b/generators/app/templates/authentication.js
@@ -15,4 +15,4 @@ module.exports = function() {
 
   <% if(authentication.length) { %>app.set('auth', config);<% } %>
   app.configure(authentication(config));
-}
+};


### PR DESCRIPTION
I did:

```bash
npm i -g yo generator-feathers
yo feathers
```

With settings:
```
? Project name feathers-ng2
? Description
? What type of API are you making? REST, Realtime via Socket.io
? CORS configuration Enabled for all domains
? What database do you primarily want to use? NeDB
? What authentication providers would you like to support? local, github
```

And `npm test` fails with:

```bash
> feathers-ng2@0.0.0 jshint /Users/avweiss/dev/feathers-ng2
> jshint src/. test/. --config

src/services/authentication/index.js: line 18, col 2, Missing semicolon.
```