### PR TITLE
Log slightly more helpful database information

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -399,7 +399,9 @@ module.exports = generators.Base.extend({
       case 'mysql':
       case 'mariadb':
       case 'postgres':
-        this.log('Make sure that your ' + this.props.database + ' database is running...');
+        this.log('Make sure that your ' + this.props.database +
+          ' database is running. The username/role is correct and the database ' 
+          + this.props.databaseName + ' has been created. Default information can be found in the projects config folder.');
         break;
     }
 


### PR DESCRIPTION
By default the generator assumes postgres, root, etc. in the connection URL. This is probably fine but running `npm start` will fail. This commit simply tells users to verify the info and the general location to look for it. 