### PR TITLE
Allow empty CORS whitelist

### DIFF
--- a/generators/app/templates/config.default.json
+++ b/generators/app/templates/config.default.json
@@ -23,7 +23,5 @@
       }
     }<% } %>
   }<% } %><% if (cors === 'whitelisted') { %>,
-  "corsWhitelist": [<% corsWhitelist.forEach(function(domain, index, list){ %>
-    "<%= domain.trim() %>"<% if(index + 1 !== list.length){ %>,<% } %><% }); %>
-  ]<% } %>
+  "corsWhitelist": [<% (corsWhitelist || []).map(function(current) { return current.trim(); }).join(', ') %>]<% } %>
 }

--- a/generators/app/templates/config.production.json
+++ b/generators/app/templates/config.production.json
@@ -22,8 +22,5 @@
         "scope": [<% for (var j=0; j < authentication[i].permissions.scope.length; j++) { %>"<%= authentication[i].permissions.scope[j]%>"<% if (j !== authentication[i].permissions.scope.length - 1) { %>,<% }} %>]
       }
     }<% } %>
-  }<% } %><% if (cors === 'whitelisted') { %>,
-  "corsWhitelist": [<% corsWhitelist.forEach(function(domain, index, list){ %>
-    "<%= domain.trim() %>"<% if(index + 1 !== list.length){ %>,<% } %><% }); %>
-  ]<% } %>
+  }<% } %>
 }

--- a/test/generators.test.js
+++ b/test/generators.test.js
@@ -31,8 +31,9 @@ describe('generator-feathers', () => {
       .withPrompts({
         name: 'myapp',
         providers: ['rest', 'socketio'],
-        cors: 'enabled',
+        cors: 'whitelisted',
         database: 'memory',
+        corsWhitelist: '',
         authentication: []
       })
       .withOptions({


### PR DESCRIPTION
This pull request allows an empty CORS whitelist and also removes the duplication from `production.json`.

Closes #85