### PR TITLE
Allow hyphenated-names in services - fixes #113

### DIFF
--- a/generators/service/index.js
+++ b/generators/service/index.js
@@ -12,6 +12,7 @@ function importService(filename, name, moduleName) {
     var ast = transform.parse(content);
 
     transform.addImport(ast, name, moduleName);
+    name = inflect.camelize(inflect.underscore(name), false);
     transform.addLastInFunction(ast, 'module.exports', 'app.configure(' + name + ');');
 
     fs.writeFileSync(filename, transform.print(ast));

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,5 +1,6 @@
 var recast = require('recast');
 var traverse = require('ast-traverse');
+var inflect = require('i')();
 
 var parse = exports.parse = function(code) {
   return recast.parse(code);
@@ -88,6 +89,9 @@ exports.addLastInFunction = function(ast, search, code) {
 };
 
 exports.addImport = function(ast, varname, modulename) {
+  
+  varname = inflect.camelize(inflect.underscore(varname), false)
+  
   ast = convert(ast);
   
   var index = 0;

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -24,6 +24,28 @@ describe('transforms', () => {
       };
     `);
   });
+
+  it('addImport with hyphenated-name', () => {
+    const ast = transform.addImport(`
+      const first = require('first');
+      
+      module.exports = function() {
+        // A comment
+      };
+    `, 'my-service', 'my-service');
+
+    const output = transform.print(ast);
+
+    assert.equal(output, `
+      const myService = require('my-service');
+      const first = require('first');
+
+      module.exports = function() {
+        // A comment
+      };
+    `);
+  });
+
   
   it('addImport with \'use strict\';', () => {
     const code = `


### PR DESCRIPTION
This is my first PR to a popular open source project, which is awesome. But if I screwed something up please let me know :-)

There wasn't a test for the complete `importService()` function.  Nor did I see an obvious place to put one. So instead I added a test for `addImport()`, and fixed that so the varName handles hyphenated-names.  This seems right to me since I don't think hyphenated-names would be OK in any use of `addImport()`

But importService(), has another instance of the same problem.  I added the fix there as well, but did NOT add a case that covers that. Not sure where to put that.  However all tests do pass!.

comments?  is this ok?

Closes https://github.com/feathersjs/feathers-cli/issues/19