### PR TITLE
Pass fewer arrow functions to Mocha. feathersjs/feathers#297

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ yo feathers:model
 yo feathers:service
 ```
 
+## Contributing
+
+To contribute PRs for these generators, you will need to clone the repo
+then inside the repo's directory, run `npm link`. This sets up a global
+link to your local package for running tests (`npm test`) and generating
+new feathers apps/services/hooks/etc.
+
+When finished testing, optionally run `npm uninstall generator-feathers` to remove
+the link.
+
 
 ## Changelog
 

--- a/generators/app/templates/static/test/app.test.js
+++ b/generators/app/templates/static/test/app.test.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const request = require('request');
 const app = require('../src/app');
 
-describe('Feathers application tests', () => {
+describe('Feathers application tests', function() {
   before(function(done) {
     this.server = app.listen(3030);
     this.server.once('listening', () => done());
@@ -14,32 +14,32 @@ describe('Feathers application tests', () => {
     this.server.close(done);
   });
 
-  it('starts and shows the index page', done => {
-    request('http://localhost:3030', (err, res, body) => {
+  it('starts and shows the index page', function(done) {
+    request('http://localhost:3030', function(err, res, body) {
       assert.ok(body.indexOf('<html>') !== -1);
       done(err);
     });
   });
 
-  describe('404', () => {
-    it('shows a 404 HTML page', done => {
+  describe('404', function() {
+    it('shows a 404 HTML page', function(done) {
       request({
         url: 'http://localhost:3030/path/to/nowhere',
         headers: {
           'Accept': 'text/html'
         }
-      }, (err, res, body) => {
+      }, function(err, res, body) {
         assert.equal(res.statusCode, 404);
         assert.ok(body.indexOf('<html>') !== -1);
         done(err);
       });
     });
 
-    it('shows a 404 JSON error without stack trace', done => {
+    it('shows a 404 JSON error without stack trace', function(done) {
       request({
         url: 'http://localhost:3030/path/to/nowhere',
         json: true
-      }, (err, res, body) => {
+      }, function(err, res, body) {
         assert.equal(res.statusCode, 404);
         assert.equal(body.code, 404);
         assert.equal(body.message, 'Page not found');

--- a/generators/hook/templates/hook.test.js
+++ b/generators/hook/templates/hook.test.js
@@ -3,8 +3,8 @@
 const assert = require('assert');
 const <%= codeName %> = require('../../../../<%= hookPath %>');
 
-describe('<%= service %> <%= codeName %> hook', () => {
-  it('hook can be used', () => {
+describe('<%= service %> <%= codeName %> hook', function() {
+  it('hook can be used', function() {
     const mockHook = {
       type: '<%= type %>',
       app: {},
@@ -12,9 +12,9 @@ describe('<%= service %> <%= codeName %> hook', () => {
       result: {},
       data: {}
     };
-    
+
     <%= codeName %>()(mockHook);
-    
+
     assert.ok(mockHook.<%= codeName %>);
   });
 });

--- a/generators/service/templates/index.test.js
+++ b/generators/service/templates/index.test.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const app = require('../../../src/app');
 
-describe('<%= name %> service', () => {
+describe('<%= name %> service', function() {
   it('registered the <%= pluralizedName %> service', () => {
     assert.ok(app.service('<%= pluralizedName %>'));
   });

--- a/test/generators.test.js
+++ b/test/generators.test.js
@@ -6,7 +6,7 @@ const helpers = require('yeoman-test');
 const exec = require('child_process').exec;
 
 
-describe('generator-feathers', () => {
+describe('generator-feathers', function() {
   let appDir;
 
   function runTest(expectedText, done) {
@@ -24,7 +24,7 @@ describe('generator-feathers', () => {
     });
   }
 
-  before(done => {
+  before(function(done) {
     helpers.run(path.join(__dirname, '../generators/app'))
       .inTmpDir(dir => appDir = dir)
       .withPrompts({
@@ -40,11 +40,11 @@ describe('generator-feathers', () => {
       }).on('end', () => done());
   });
 
-  it('feathers:app', done => {
+  it('feathers:app', function(done) {
     runTest('starts and shows the index page', done);
   });
 
-  it('feathers:service(memory)', done => {
+  it('feathers:service(memory)', function(done) {
     helpers.run(path.join(__dirname, '../generators/service'))
       .inTmpDir(() => process.chdir(appDir))
       .withPrompts({
@@ -57,7 +57,7 @@ describe('generator-feathers', () => {
       );
   });
 
-  it('feathers:service(generic)', done => {
+  it('feathers:service(generic)', function(done) {
     helpers.run(path.join(__dirname, '../generators/service'))
       .inTmpDir(() => process.chdir(appDir))
       .withPrompts({
@@ -69,7 +69,7 @@ describe('generator-feathers', () => {
       );
   });
 
-  it('feathers:hook', done => {
+  it('feathers:hook', function(done) {
     helpers.run(path.join(__dirname, '../generators/hook'))
       .inTmpDir(() => process.chdir(appDir))
       .withPrompts({


### PR DESCRIPTION
This PR addresses an issue I had trying to increase the timeout of a test, which wouldn't work due to the generated test passing arrow functions to mocha. From mocha docs:

>Passing arrow functions to Mocha is discouraged. Their lexical binding of the this value makes them unable to access the Mocha context, and statements like this.timeout(1000); will not work inside an arrow function.

[https://mochajs.org/#arrow-functions](https://mochajs.org/#arrow-functions).

I did not replace every arrow function in the test templates, as some of them seemed like they would never cause any issues. Also added notes to the README describing how to make changes to and test the generators via `npm link` (many people will likely already know this, I did not.)
