### PR TITLE
Run the generator tests without Babel to make sure they pass in their…

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -421,8 +421,9 @@ module.exports = generators.Base.extend({
       case 'mariadb':
       case 'postgres':
         this.log('Make sure that your ' + this.props.database +
-          ' database is running. The username/role is correct and the database ' 
-          + this.props.databaseName + ' has been created. Default information can be found in the projects config folder.');
+          ' database is running. The username/role is correct and the database ' +
+          this.props.databaseName + ' has been created. ' +
+          'Default information can be found in the projects config folder.');
         break;
     }
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -89,8 +89,7 @@ exports.addLastInFunction = function(ast, search, code) {
 };
 
 exports.addImport = function(ast, varname, modulename) {
-  
-  varname = inflect.camelize(inflect.underscore(varname), false)
+  varname = inflect.camelize(inflect.underscore(varname), false);
   
   ast = convert(ast);
   

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "test": "mocha test/ --compilers js:babel-core/register --timeout 300000"
+    "jshint": "jshint lib/. generators/**/index.js test/. --config",
+    "test:transform": "mocha test/transform.test.js --compilers js:babel-core/register",
+    "test:generators": "mocha test/generators.test.js --timeout 300000",
+    "test": "npm run jshint && npm run test:transform && npm run test:generators"
   },
   "files": [
     "generators/app",
@@ -65,6 +68,7 @@
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.0",
     "babel-preset-es2015": "^6.6.0",
+    "jshint": "^2.9.2",
     "mocha": "^2.4.5",
     "yeoman-test": "^1.1.0"
   }

--- a/test/generators.test.js
+++ b/test/generators.test.js
@@ -1,20 +1,23 @@
 'use strict';
 
-const assert = require('assert');
-const path = require('path');
-const helpers = require('yeoman-test');
-const exec = require('child_process').exec;
+var assert = require('assert');
+var path = require('path');
+var helpers = require('yeoman-test');
+var exec = require('child_process').exec;
 
 
 describe('generator-feathers', function() {
-  let appDir;
+  var appDir;
 
   function runTest(expectedText, done) {
-    let child = exec('npm test', { cwd: appDir });
-    let buffer = '';
+    var child = exec('npm test', { cwd: appDir });
+    var buffer = '';
+    var addToBuffer = function(data) {
+      buffer += data;
+    };
 
-    child.stdout.on('data', data => buffer += data);
-    child.stderr.on('data', data => buffer += data);
+    child.stdout.on('data', addToBuffer);
+    child.stderr.on('data', addToBuffer);
 
     child.on('exit', function (status) {
       if(status !== 0) {
@@ -29,7 +32,9 @@ describe('generator-feathers', function() {
 
   before(function(done) {
     helpers.run(path.join(__dirname, '../generators/app'))
-      .inTmpDir(dir => appDir = dir)
+      .inTmpDir(function(dir) {
+        appDir = dir;
+      })
       .withPrompts({
         name: 'myapp',
         providers: ['rest', 'socketio'],
@@ -40,7 +45,9 @@ describe('generator-feathers', function() {
       })
       .withOptions({
         skipInstall: false
-      }).on('end', () => done());
+      }).on('end', function() {
+        done();
+      });
   });
 
   it('feathers:app', function(done) {
@@ -49,40 +56,46 @@ describe('generator-feathers', function() {
 
   it('feathers:service(memory)', function(done) {
     helpers.run(path.join(__dirname, '../generators/service'))
-      .inTmpDir(() => process.chdir(appDir))
+      .inTmpDir(function() {
+        process.chdir(appDir);
+      })
       .withPrompts({
         type: 'database',
         database: 'memory',
         name: 'messages'
       })
-      .on('end', () =>
-        runTest('registered the messages service', done)
-      );
+      .on('end', function() {
+        runTest('registered the messages service', done);
+      });
   });
 
   it('feathers:service(generic)', function(done) {
     helpers.run(path.join(__dirname, '../generators/service'))
-      .inTmpDir(() => process.chdir(appDir))
+      .inTmpDir(function() {
+        process.chdir(appDir);
+      })
       .withPrompts({
         type: 'generic',
         name: 'tests'
       })
-      .on('end', () =>
-        runTest('registered the tests service', done)
-      );
+      .on('end', function() {
+        runTest('registered the tests service', done);
+      });
   });
 
   it('feathers:hook', function(done) {
     helpers.run(path.join(__dirname, '../generators/hook'))
-      .inTmpDir(() => process.chdir(appDir))
+      .inTmpDir(function() {
+        process.chdir(appDir);
+      })
       .withPrompts({
         type: 'before',
         service: 'messages',
         method: ['create', 'update', 'patch'],
         name: 'removeId'
       })
-      .on('end', () =>
-        runTest('hook can be used', done)
-      );
+      .on('end', function() {
+        runTest('hook can be used', done);
+      });
   });
 });


### PR DESCRIPTION
… respective Node version. We will need this even if we change the generator as long as we plan to support versions older than 5.