### PR TITLE
Add associate() to sequelize models

### DIFF
--- a/generators/app/templates/service.js
+++ b/generators/app/templates/service.js
@@ -23,4 +23,12 @@ module.exports = function() {
   <% if (localAuth || authentication.length) { %>
   app.configure(authentication);<% } %><% for (var i = 0; i < services.length; i++) { %>
   app.configure(<%= services[i] %>);<% } %>
+  <% if (database === 'sqlite' || database === 'mssql' || database === 'postgres' || database === 'mysql' || database === 'mariadb') { %>
+  const {models} = sequelize;
+  app.set('models', models);
+  Object.keys(models).forEach(name => {
+    if ('associate' in models[name]) {
+      models[name].associate(models, sequelize);
+    }
+  });<% } %>
 };

--- a/generators/model/templates/sequelize.js
+++ b/generators/model/templates/sequelize.js
@@ -26,7 +26,12 @@ module.exports = function(sequelize) {
       allowNull: false
     }<% } %>
   }, {
-    freezeTableName: true
+    freezeTableName: true,
+    classMethods: {
+      associate(models, sequelize) {
+        // Define associations here
+      }
+    }
   });
 
   <%= name %>.sync();


### PR DESCRIPTION
This adds a helpful `associate()` function to sequelize models which makes describing relational connections more straight forward.
