### PR TITLE
Move freezeTableName so it doesn't need to be set on every model.

### DIFF
--- a/generators/app/templates/service.js
+++ b/generators/app/templates/service.js
@@ -11,11 +11,17 @@ module.exports = function() {
   const sequelize = new Sequelize('feathers', null, null, {
     dialect: 'sqlite',
     storage: app.get('sqlite'),
-    logging: false
+    logging: false,
+    define: {
+      freezeTableName: true
+    }
   });<% } else if (database === 'postgres' || database === 'mysql' || database === 'mariadb' || database === 'mssql') { %>
   const sequelize = new Sequelize(app.get('<%= database %>'), {
     dialect: '<%= database %>',
-    logging: false
+    logging: false,
+    define: {
+      freezeTableName: true
+    }
   });<% } else if (database === 'mongodb') { %>
   mongoose.connect(app.get('mongodb'));
   mongoose.Promise = global.Promise;<% } %><% if (database === 'sqlite' || database === 'mssql' || database === 'postgres' || database === 'mysql' || database === 'mariadb') { %>

--- a/generators/model/templates/sequelize.js
+++ b/generators/model/templates/sequelize.js
@@ -25,8 +25,6 @@ module.exports = function(sequelize) {
       type: Sequelize.STRING,
       allowNull: false
     }<% } %>
-  }, {
-    freezeTableName: true
   });
 
   <%= name %>.sync();


### PR DESCRIPTION
Not sure how you feel about this, but it seems very redundant to me having `freezeTableName: true` appear in every single model when it could just be set in the Sequelize connection constructor call.