### PR TITLE
Suggest valid RethinkDB database name and prevent overwriting configuration settings

### DIFF
--- a/generators/connection/index.js
+++ b/generators/connection/index.js
@@ -224,7 +224,7 @@ module.exports = class ConnectionGenerator extends Generator {
             nedb: 'nedb://../data',
             // oracle: `oracle://root:password@localhost:1521/${databaseName}`,
             postgres: `postgres://postgres:@localhost:5432/${databaseName}`,
-            rethinkdb: `rethinkdb://localhost:11078/${databaseName}`,
+            rethinkdb: `rethinkdb://localhost:28015/${databaseName}`,
             sqlite: `sqlite://${databaseName}.sqlite`,
             mssql: `mssql://root:password@localhost:1433/${databaseName}`
           };

--- a/generators/connection/index.js
+++ b/generators/connection/index.js
@@ -55,7 +55,7 @@ module.exports = class ConnectionGenerator extends Generator {
     case 'rethinkdb':
       this.dependencies.push('rethinkdbdash');
       return {
-        database: parsed.path.substring(1, parsed.path.length),
+        db: parsed.path.substring(1, parsed.path.length),
         servers: [
           {
             host: parsed.hostname,


### PR DESCRIPTION
Prevent overwriting RethinkDB connection details by re-using existing
configuration settings.

Default to a valid RethinkDB database name.

closes #174 and #173 