### PR TITLE
Add a successRedirect by default

### DIFF
--- a/generators/authentication/templates/authentication.js
+++ b/generators/authentication/templates/authentication.js
@@ -21,7 +21,8 @@ module.exports = function() {
   <% oauthProviders.forEach(provider => { %>
   app.configure(oauth2(Object.assign({
     name: '<%= provider.name %>',
-    Strategy: <%= provider.strategyName %>
+    Strategy: <%= provider.strategyName %>,
+    successRedirect: '/'
   }, config.<%= provider.name %>)));
   <% }); %>
 


### PR DESCRIPTION
It makes more sense to have a successRedirect by default.  This way the user doesn’t see naked JSON in the auth response.