### PR TITLE
Allow tests to be in nested folder

### DIFF
--- a/generators/app/configs/package.json.js
+++ b/generators/app/configs/package.json.js
@@ -18,7 +18,7 @@ module.exports = function(generator) {
     contributors: [],
     bugs: {},
     directories: {
-      lib, testLib: ''
+      lib, libTest: ''
     },
     engines: {
       node: '>= 6.0.0',

--- a/generators/app/configs/package.json.js
+++ b/generators/app/configs/package.json.js
@@ -18,7 +18,7 @@ module.exports = function(generator) {
     contributors: [],
     bugs: {},
     directories: {
-      lib
+      lib, testLib: ''
     },
     engines: {
       node: '>= 6.0.0',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -150,7 +150,7 @@ module.exports = class AppGenerator extends Generator {
 
     this.fs.copyTpl(
       this.templatePath('app.test.js'),
-      this.destinationPath('test', 'app.test.js'),
+      this.destinationPath('test', this.libTestDirectory, 'app.test.js'),
       context
     );
 

--- a/generators/hook/index.js
+++ b/generators/hook/index.js
@@ -152,7 +152,7 @@ module.exports = class HookGenerator extends Generator {
 
     this.fs.copyTpl(
       this.templatePath('test.js'),
-      this.destinationPath('test', 'hooks', `${context.kebabName}.test.js`),
+      this.destinationPath('test', this.libTestDirectory, 'hooks', `${context.kebabName}.test.js`),
       context
     );
   }

--- a/generators/service/index.js
+++ b/generators/service/index.js
@@ -209,7 +209,7 @@ module.exports = class ServiceGenerator extends Generator {
 
     this.fs.copyTpl(
       this.templatePath('test.js'),
-      this.destinationPath('test', 'services', `${kebabName}.test.js`),
+      this.destinationPath('test', this.libTestDirectory, 'services', `${kebabName}.test.js`),
       context
     );
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -32,8 +32,12 @@ module.exports = class BaseGenerator extends Generator {
     return this.pkg.directories && this.pkg.directories.lib;
   }
 
+  get libTestDirectory() {
+    return this.pkg.directories && this.pkg.directories.libTest;
+  }
+
   _packagerInstall(... args) {
-    const packager = this.pkg.engines && this.pkg.engines.yarn ? 
+    const packager = this.pkg.engines && this.pkg.engines.yarn ?
       'yarn' : 'npm';
     const method = `${packager}Install`;
 


### PR DESCRIPTION
I have my tests not in `test/etc`, but in `test/api/etc`. This PR allows an additional directories config to be respected by the generators.

package.json:
```
...
"directories": {
  "lib": "src/api",
  "testLib": "api" // <--
}
...
```

I'm new to both generators and feathersjs, so I'm probably missing something. In that case, I'd like to invite you to add the missing pieces.