### PR TITLE
Do not overwrite connection files when generating a service

### DIFF
--- a/generators/connection/index.js
+++ b/generators/connection/index.js
@@ -266,9 +266,10 @@ module.exports = class ConnectionGenerator extends Generator {
 
     if (template) {
       const dbFile = `${database}.js`;
+      const templateExists = this.fs.exists(this.destinationPath(this.libDirectory, dbFile));
 
       // If the file doesn't exist yet, add it to the app.js
-      if (!this.fs.exists(this.destinationPath(this.libDirectory, dbFile))) {
+      if (!templateExists) {
         const appjs = this.destinationPath(this.libDirectory, 'app.js');
 
         this.conflicter.force = true;
@@ -277,11 +278,15 @@ module.exports = class ConnectionGenerator extends Generator {
         ));
       }
 
-      this.fs.copyTpl(
-        this.templatePath(template),
-        this.destinationPath(this.libDirectory, dbFile),
-        context
-      );
+      // Copy template only if connection generate is not composed
+      // from the service generator
+      if(!templateExists || (templateExists && !this.props.service)) {
+        this.fs.copyTpl(
+          this.templatePath(template),
+          this.destinationPath(this.libDirectory, dbFile),
+          context
+        );
+      }
     }
 
     this._writeConfiguration();

--- a/generators/service/index.js
+++ b/generators/service/index.js
@@ -161,7 +161,10 @@ module.exports = class ServiceGenerator extends Generator {
     // It will not do anything if the db has been set up already
     if (adapter !== 'generic' && adapter !== 'memory') {
       this.composeWith(require.resolve('../connection'), {
-        props: { adapter }
+        props: {
+          adapter,
+          service: this.props.name
+        }
       });
     } else if(adapter === 'generic') {
       // Copy the generic service class


### PR DESCRIPTION
Currently, every time you generate a service the connection generator will force overwrite its connection file. This pull request fixes that.