### PR TITLE
Generate sequelize model according to sequelize 4.0

### DIFF
--- a/generators/service/templates/model/sequelize.js
+++ b/generators/service/templates/model/sequelize.js
@@ -9,14 +9,12 @@ module.exports = function (app) {
       type: Sequelize.STRING,
       allowNull: false
     }
-  }, {
-    classMethods: {
-      associate (models) { // eslint-disable-line no-unused-vars
-        // Define associations here
-        // See http://docs.sequelizejs.com/en/latest/docs/associations/
-      }
-    }
   });
+
+  <%= camelName %>.associate = function (models) { // eslint-disable-line no-unused-vars
+    // Define associations here
+    // See http://docs.sequelizejs.com/en/latest/docs/associations/
+  };
 
   return <%= camelName %>;
 };


### PR DESCRIPTION
`classMethods` is deprecated as of 4.0.0
See http://docs.sequelizejs.com/manual/tutorial/upgrade-to-v4.html