### PR TITLE
Improve order of generated middleware

### DIFF
--- a/generators/app/templates/app.js
+++ b/generators/app/templates/app.js
@@ -11,6 +11,9 @@ const hooks = require('feathers-hooks');
 <% if (hasProvider('rest')) { %>const rest = require('feathers-rest');<% } %>
 <% if (hasProvider('socketio')) { %>const socketio = require('feathers-socketio');<% } %>
 <% if (hasProvider('primus')) { %>const primus = require('feathers-primus');<% } %>
+const handler = require('feathers-errors/handler');
+const notFound = require('feathers-errors/not-found');
+
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');
@@ -28,6 +31,8 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
 // Host the public folder
 app.use('/', feathers.static(app.get('public')));
+// Configure other middleware (see `middleware/index.js`)
+app.configure(middleware);
 
 // Set up Plugins and providers
 app.configure(hooks());
@@ -36,8 +41,10 @@ app.configure(hooks());
 <% if(hasProvider('primus')) { %>app.configure(primus({ transformer: 'websockets' }));<% } %>
 // Set up our services (see `services/index.js`)
 app.configure(services);
-// Configure middleware (see `middleware/index.js`) - always has to be last
-app.configure(middleware);
+// Configure a middleware for 404s and the error handler
+app.use(notFound());
+app.use(handler());
+
 app.hooks(appHooks);
 
 module.exports = app;

--- a/generators/app/templates/src/middleware/index.js
+++ b/generators/app/templates/src/middleware/index.js
@@ -1,12 +1,6 @@
-const handler = require('feathers-errors/handler');
-const notFound = require('feathers-errors/not-found');
-
 module.exports = function () {
   // Add your custom middleware here. Remember, that
   // in Express the order matters, `notFound` and
   // the error handler have to go last.
-  const app = this;
-
-  app.use(notFound());
-  app.use(handler());
+  const app = this; // eslint-disable-line no-unused-vars
 };


### PR DESCRIPTION
Generated middleware was only registered at the end (after all services). This means that it never got hit for service calls (e.g. not allowing to add things to `params`). It makes more sense to register the middleware before services and adding the `notFound` and error handler in the main `app.js`.

Closes #221 