### PR TITLE
Minor changes to the generated index.html

### DIFF
--- a/generators/app/templates/static/public/index.html
+++ b/generators/app/templates/static/public/index.html
@@ -66,7 +66,7 @@
       <h2 class="center-text">A REST and realtime API layer for modern applications.</h2>
 
       <footer>
-        <p class="center-text">For more information on Feathers see <a href="http://docs.feathersjs.com" alt="Feathers Documentation" target="blank">docs.feathersjs.com</a>.</p>
+        <p class="center-text">For more information on Feathers see <a href="https://docs.feathersjs.com" title="Feathers Documentation" target="blank">docs.feathersjs.com</a>.</p>
       </footer>
     </main>
   </body>


### PR DESCRIPTION
- Link to https docs
- Use `title` instead of `alt` on the link to the docs