### PR TITLE
Use latest pg driver again

### DIFF
--- a/generators/connection/index.js
+++ b/generators/connection/index.js
@@ -37,7 +37,7 @@ module.exports = class ConnectionGenerator extends Generator {
       mariadb: 'mysql',
       mysql: 'mysql2',
       mssql: 'tedious',
-      postgres: 'pg@6',
+      postgres: 'pg',
       sqlite: 'sqlite3'
       // oracle: 'oracle'
     };


### PR DESCRIPTION
Broken pg@7 support has been fixed via https://github.com/sequelize/sequelize/pull/7888

Closes https://github.com/feathersjs/generator-feathers/issues/246 and closes https://github.com/feathersjs/generator-feathers/issues/259