### PR TITLE
Adding generator support for NoSQL schemas

### DIFF
--- a/generators/schema/index.js
+++ b/generators/schema/index.js
@@ -1,0 +1,67 @@
+const _ = require('lodash');
+const Generator = require('../../lib/generator');
+const j = require('../../lib/transform');
+
+module.exports = class SchemaGenerator extends Generator {
+  prompting() {
+    this.checkPackage();
+
+    const prompts = [{
+      name: 'service',
+      message: 'What is the name of the service?',
+      validate(input) {
+        if (input.trim() === '') {
+          return 'Service name can not be empty';
+        }
+
+        return true;
+      }
+    }];
+    return this.prompt(prompts).then(props => {
+      this.props = Object.assign(this.props, props, {
+        kebabName: _.kebabCase(props.service),
+        snakeName: _.snakeCase(props.service)
+      });
+    });
+  }
+
+  _transformCode(code) {
+    const ast = j(code);
+    const moduleExports = ast.find(j.ExpressionStatement);
+
+    if (moduleExports.length === 0) {
+      throw new Error('Count not find module.exports.');
+    }
+
+    moduleExports.insertBefore(`const ${this.props.snakeName}Schema = require(\'./${this.props.kebabName}.schema\');`);
+    ast.insertHookAsIs('before', 'create', `...${this.props.snakeName}Schema.hooks`);
+    ast.insertHookAsIs('before', 'update', `...${this.props.snakeName}Schema.hooks`);
+    ast.insertHookAsIs('before', 'patch', `...${this.props.snakeName}Schema.hooks`);
+
+    return ast.toSource();
+  }
+
+  writing() {
+    const dependencies = [
+      'feathers-schema'
+    ];
+
+    const hooksjs = this.destinationPath(this.libDirectory, 'services', this.props.kebabName, `${this.props.kebabName}.hooks.js`);
+
+    if (this.fs.exists(hooksjs)) {
+      this.fs.write(hooksjs, this._transformCode(
+        this.fs.read(hooksjs).toString()
+      ));
+    }
+
+    this.fs.copyTpl(
+      this.templatePath('template.schema.js'),
+      this.destinationPath(this.libDirectory, 'services', this.props.kebabName, `${this.props.kebabName}.schema.js`),
+      this.props
+    );
+
+    this._packagerInstall(dependencies, {
+      save: true
+    });
+  }
+};

--- a/generators/schema/index.js
+++ b/generators/schema/index.js
@@ -33,7 +33,7 @@ module.exports = class SchemaGenerator extends Generator {
       throw new Error('Count not find module.exports.');
     }
 
-    moduleExports.insertBefore(`const ${this.props.snakeName}Schema = require(\'./${this.props.kebabName}.schema\');`);
+    moduleExports.insertBefore(`const ${this.props.snakeName}Schema = require('./${this.props.kebabName}.schema');`);
     ast.insertHookAsIs('before', 'create', `...${this.props.snakeName}Schema.hooks`);
     ast.insertHookAsIs('before', 'update', `...${this.props.snakeName}Schema.hooks`);
     ast.insertHookAsIs('before', 'patch', `...${this.props.snakeName}Schema.hooks`);

--- a/generators/schema/templates/template.schema.js
+++ b/generators/schema/templates/template.schema.js
@@ -1,0 +1,6 @@
+const Schema = require('feathers-schema').Schema;
+
+// Guide for using schema here: https://www.npmjs.com/package/feathers-schema
+module.exports = new Schema({
+  name: String
+});

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -37,6 +37,27 @@ j.registerMethods({
     return this;
   },
 
+  insertHookAsIs(type, method, name) {
+    let current = this.findIdentifier(type).closest(j.Property);
+
+    if(!current.length) {
+      throw new Error(`No hook declaration object for '${type}' hooks found.`);
+    }
+
+    current = current.findIdentifier(method).closest(j.Property);
+
+    if(!current.length) {
+      throw new Error(`No method declaration object for hook type '${type}' and method '${method}' found.`);
+    }
+
+    current.find(j.ArrayExpression)
+      .forEach(prop =>
+        prop.value.elements.push(name)
+      );
+
+    return this;
+  },
+
   findExpressionStatement(identifier, name = '') {
     let result = this.findIdentifier(identifier)
       .closest(j.ExpressionStatement);


### PR DESCRIPTION
Uses feathers-schema to generate a schema for json entries in a NoSQL database. Generates on top of a service, populates the hooks and creates the schema template as ```<service>.schema.js```.