### PR TITLE
Remove template strings in index.js

### DIFF
--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -9,5 +9,5 @@ process.on('unhandledRejection', (reason, p) =>
 );
 
 server.on('listening', () =>
-  logger.info(`Feathers application started on ${app.get('host')}:${port}`)
+  logger.info('Feathers application started on %s:%d', app.get('host'), port)
 );


### PR DESCRIPTION
It's still better without, is not it ?

Allows to use the power of winston with `string interpolation`