### PR TITLE
remove useless config.local

### DIFF
--- a/generators/authentication/templates/authentication.js
+++ b/generators/authentication/templates/authentication.js
@@ -11,7 +11,7 @@ module.exports = function () {
   // Set up authentication with the secret
   app.configure(authentication(config));
   app.configure(jwt());<% if(strategies.indexOf('local') !== -1) { %>
-  app.configure(local(config.local));<% } %>
+  app.configure(local());<% } %>
 <% oauthProviders.forEach(provider => { %>
   app.configure(oauth2(Object.assign({
     name: '<%= provider.name %>',


### PR DESCRIPTION
According to https://github.com/feathersjs/feathers-authentication-local/blob/master/src/index.js#L34, `config.local` is already taken from `config.authentication`. Therefore, to be consistent with the previous line (`jwt()` and not `jwt(config.jwt)`), `config.local` is useless and should be removed.