### PR TITLE
make default message clickable on iTerm

### DIFF
--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -9,5 +9,5 @@ process.on('unhandledRejection', (reason, p) =>
 );
 
 server.on('listening', () =>
-  logger.info('Feathers application started on %s:%d', app.get('host'), port)
+  logger.info('Feathers application started on http://%s:%d', app.get('host'), port)
 );


### PR DESCRIPTION
Holding Mod and hovering over the message doesn't allow you to click to open a tab. Frustrating on iTerm.