### PR TITLE
added regex to prevent illegal characters error for Project Name

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -14,6 +14,22 @@ try {
 module.exports = class AppGenerator extends Generator {
   constructor (args, opts) {
     super(args, opts);
+    
+    const regex = /[\w+\-]\w+/g;
+    const str = `feathers-chat`;
+    let m;
+  
+    while ((m = regex.exec(str)) !== null) {
+      // This is necessary to avoid infinite loops with zero-width matches
+      if (m.index === regex.lastIndex) {
+        regex.lastIndex++;
+      }
+    
+      // The result can be accessed through the `m`-variable.
+      m.forEach((match, groupIndex) => {
+        console.log(`Found match, group ${groupIndex}: ${match}`);
+      });
+    }
 
     this.props = {
       name: this.pkg.name || process.cwd().split(path.sep).pop(),


### PR DESCRIPTION
# Illegal Characters Error 
---
After entering the `$ feathers generate app` command, it allows the User to write a custom 'Project Name'. If the User includes spaces in the name, it results in 'error - illegal characters / ERR! Invalid Name:'.

Added regex to prevent user from writing a Project Name with spaces.

I'm new to GitHub and not sure if where I added the regex code is best practice.

---
Screen shot of the command `$ feathers generate app` , the User writing Project Name, and the according error at the bottom.


![illegal characters error for project name](https://user-images.githubusercontent.com/24982353/30246679-cebeda2c-95b5-11e7-9d85-3fd55d652cc4.png)
