### PR TITLE
Add alternative start script for cool kids with Node 8.5

### DIFF
--- a/generators/app/configs/package.json.js
+++ b/generators/app/configs/package.json.js
@@ -29,6 +29,7 @@ module.exports = function(generator) {
       test: 'npm run eslint && npm run mocha',
       eslint: `eslint ${lib}/. test/. --config .eslintrc.json`,
       start: `node ${lib}/`,
+      startLatest: `"node --experimental-modules --inspect=9030 ${lib}/"`,
       mocha: 'mocha test/ --recursive'
     }
   };


### PR DESCRIPTION
Having the inspector by default without polluting the environment with NODE_OPTION and being able to use esm and other goodies out of the box is really nice.