### PR TITLE
Add --exit flag for Mocha 4

### DIFF
--- a/generators/app/configs/package.json.js
+++ b/generators/app/configs/package.json.js
@@ -29,7 +29,7 @@ module.exports = function(generator) {
       test: 'npm run eslint && npm run mocha',
       eslint: `eslint ${lib}/. test/. --config .eslintrc.json`,
       start: `node ${lib}/`,
-      mocha: 'mocha test/ --recursive'
+      mocha: 'mocha test/ --recursive --exit'
     }
   };
 


### PR DESCRIPTION
Otherwise PRs and tests are failing (since it installs the latest version).