### PR TITLE
Use the selected packager to run commands

### DIFF
--- a/generators/app/configs/package.json.js
+++ b/generators/app/configs/package.json.js
@@ -26,7 +26,7 @@ module.exports = function(generator) {
       [packager]: version
     },
     'scripts': {
-      test: 'npm run eslint && npm run mocha',
+      test: `${packager} run eslint && ${packager} run mocha`,
       eslint: `eslint ${lib}/. test/. --config .eslintrc.json`,
       start: `node ${lib}/`,
       mocha: 'mocha test/ --recursive --exit'


### PR DESCRIPTION
I think we want `yarn` if the user selected it as the package manager.