### PR TITLE
Prevent crashes if there is no "proper" registered service

### DIFF
--- a/generators/service/templates/service.js
+++ b/generators/service/templates/service.js
@@ -18,6 +18,7 @@ module.exports = function (app) {
 
   // Get our initialized service so that we can register hooks and filters
   const service = app.service('<%= path %>');
-
-  service.hooks(hooks);
+  if(service) {
+    service.hooks(hooks);
+  }
 };


### PR DESCRIPTION
Hi,

I'm new to feather, sorry if it's the wong approach.

But if someone do not provide a service class but a custom express function like for example `app.use('/my-service', (req, res) => {res.send('Hello world');});` no service is registered and the `service` variable will be undefined. As a result `service.hooks(hooks);` crashes
