### PR TITLE
Update mongoose.js

### DIFF
--- a/generators/connection/templates/mongoose.js
+++ b/generators/connection/templates/mongoose.js
@@ -1,9 +1,7 @@
 const mongoose = require('mongoose');
 
 module.exports = function (app) {
-  mongoose.connect(app.get('mongodb'), {
-    useMongoClient: true
-  });
+  mongoose.connect(app.get('mongodb'), {});
   mongoose.Promise = global.Promise;
 
   app.set('mongooseClient', mongoose);


### PR DESCRIPTION
The `useMongoClient` option is no longer necessary in mongoose 5.x, please remove it.