### PR TITLE
Do not fail when the services index has been modified

### DIFF
--- a/generators/service/index.js
+++ b/generators/service/index.js
@@ -101,18 +101,23 @@ module.exports = class ServiceGenerator extends Generator {
     const ast = j(code);
     const mainExpression = ast.find(j.FunctionExpression)
       .closest(j.ExpressionStatement);
-
-    if(mainExpression.length !== 1) {
-      throw new Error(`${this.libDirectory}/services/index.js seems to have more than one function declaration and we can not register the new service. Did you modify it?`);
-    }
-
     const serviceRequire = `const ${camelName} = require('./${kebabName}/${kebabName}.service.js');`;
     const serviceCode = `app.configure(${camelName});`;
-
-    // Add require('./service')
-    mainExpression.insertBefore(serviceRequire);
-    // Add app.configure(service) to service/index.js
-    mainExpression.insertLastInFunction(serviceCode);
+    
+    if(mainExpression.length !== 1) {
+      this.log
+        .writeln()
+        .conflict(`${this.libDirectory}/services/index.js seems to have more than one function declaration and we can not register the new service. Did you modify it?`)
+        .info('You will need to add the next lines manually to the file')
+        .info(serviceRequire)
+        .info(serviceCode)
+        .writeln();
+    } else {
+      // Add require('./service')
+      mainExpression.insertBefore(serviceRequire);
+      // Add app.configure(service) to service/index.js
+      mainExpression.insertLastInFunction(serviceCode);
+    }
 
     return ast.toSource();
   }


### PR DESCRIPTION
Hello!

This is related to https://github.com/feathersjs/generator-feathers/issues/304. I encountered the same problem, because I'm using an arrow function instead of plain old function declaration.

I made the code print a message instead of throwing if it wasn't able to find the main function, so you just have to copy the line manually. It look like this:

![capture d ecran 2018-01-25 a 17 02 29](https://user-images.githubusercontent.com/923718/35415591-25aaad52-01f4-11e8-843e-096e90f3dc59.png)

 I am then able to use the generators even if my`services/index.js` is modified.