### PR TITLE
fix port

### DIFF
--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const logger = require('winston');
 const app = require('./app');
-const port = app.get('port');
+const port = process.env.PORT || app.get('port');
 const server = app.listen(port);
 
 process.on('unhandledRejection', (reason, p) =>


### PR DESCRIPTION
I've made a minor fix related to port configuration. Cloud services like Heroku or Azure set up environment PORT variable and the app should use that value. I spent several hours to figure out while deploing my app on Azure. This may save the time for someone else who using the generator.