### PR TITLE
Use cors after helmet

### DIFF
--- a/generators/app/templates/app.js
+++ b/generators/app/templates/app.js
@@ -1,8 +1,8 @@
 const path = require('path');
 const favicon = require('serve-favicon');
 const compress = require('compression');
-const cors = require('cors');
 const helmet = require('helmet');
+const cors = require('cors');
 const logger = require('winston');
 
 const feathers = require('@feathersjs/feathers');
@@ -20,9 +20,9 @@ const app = express(feathers());
 
 // Load app configuration
 app.configure(configuration());
-// Enable CORS, security, compression, favicon and body parsing
-app.use(cors());
+// Enable security, CORS, compression, favicon and body parsing
 app.use(helmet());
+app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
Using the cors middleware after the helmet middleware allows helmet to secure OPTIONS requests. See https://github.com/helmetjs/helmet/issues/157.