### PR TITLE
Fixed comment typo on line 51

### DIFF
--- a/generators/app/templates/src/channels.js
+++ b/generators/app/templates/src/channels.js
@@ -48,7 +48,7 @@ module.exports = function(app) {
   });
 
   // Here you can also add service specific event publishers
-  // e..g the publish the `users` service `created` event to the `admins` channel
+  // e.g. the publish the `users` service `created` event to the `admins` channel
   // app.service('users').publish('created', () => app.channel('admins'));
   
   // With the userid and email organization from above you can easily select involved users


### PR DESCRIPTION
Fixed comment typo on line 51 in `/generators/app/templates/src/channels.js`

Before: `// e..g`
After: `// e.g.`