### PR TITLE
Remove "and filters" from a comment in the service.js template

### DIFF
--- a/generators/service/templates/service.js
+++ b/generators/service/templates/service.js
@@ -15,7 +15,7 @@ module.exports = function (app) {
   // Initialize our service with any options it requires
   app.use('/<%= path %>', createService(options));
 
-  // Get our initialized service so that we can register hooks and filters
+  // Get our initialized service so that we can register hooks
   const service = app.service('<%= path %>');
 
   service.hooks(hooks);


### PR DESCRIPTION
Filters no longer exist (or at least, are not documented) in recent versions