### PR TITLE
Extend config to optionally receive port env var

### DIFF
--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const logger = require('winston');
 const app = require('./app');
-const port = app.get('port');
+const port = process.env.PORT || app.get('port');
 const server = app.listen(port);
 
 process.on('unhandledRejection', (reason, p) =>


### PR DESCRIPTION
This change removes an unnecessary barrier to application deployment. Hosting services (e.g.: Heroku) may not always run the application on 80. Adding this one-line change makes services that provide the port through environmental vars work straight out of the @Feathers-cli box.