### PR TITLE
Allow generating services in nested folders

### DIFF
--- a/generators/service/templates/service.js
+++ b/generators/service/templates/service.js
@@ -1,6 +1,6 @@
 // Initializes the `<%= name %>` service on path `/<%= path %>`
 const createService = require('<%= serviceModule %>');<% if(modelName) { %>
-const createModel = require('../../models/<%= modelName %>');<% } %>
+const createModel = require('<%= relativeRoot %>models/<%= modelName %>');<% } %>
 const hooks = require('./<%= kebabName %>.hooks');
 
 module.exports = function (app) {

--- a/generators/service/templates/test.js
+++ b/generators/service/templates/test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const app = require('../../<%= libDirectory %>/app');
+const app = require('<%= relativeRoot %><%= libDirectory %>/app');
 
 describe('\'<%= name %>\' service', () => {
   it('registered the service', () => {

--- a/generators/service/templates/types/knex.js
+++ b/generators/service/templates/types/knex.js
@@ -1,6 +1,6 @@
 // Initializes the `<%= name %>` service on path `/<%= path %>`
 const createService = require('<%= serviceModule %>');
-const createModel = require('../../models/<%= modelName %>');
+const createModel = require('<%= relativeRoot %>models/<%= modelName %>');
 const hooks = require('./<%= kebabName %>.hooks');
 
 module.exports = function (app) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,13 @@
         "recast": "^0.11.11",
         "temp": "^0.8.1",
         "write-file-atomic": "^1.2.0"
+      },
+      "dependencies": {
+        "node-dir": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
+          "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30="
+        }
       }
     },
     "@feathersjs/tools": {
@@ -4586,9 +4593,12 @@
       "dev": true
     },
     "node-dir": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
-      "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30="
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
     },
     "nomnom": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@feathersjs/jscodeshift": "^0.5.0",
     "@feathersjs/tools": "^0.1.0",
     "lodash": "^4.17.4",
+    "node-dir": "^0.1.17",
     "randomstring": "^1.1.5",
     "semver": "^5.4.1",
     "yeoman-generator": "^2.0.0"


### PR DESCRIPTION
This allows to generate services with names in nested folders like `blog/posts` or `v1/dashboard`.

Closes #341, closes #342