### PR TITLE
Fix 404 JSON smoke test in generated app.test.js

### DIFF
--- a/generators/app/templates/app.test.js
+++ b/generators/app/templates/app.test.js
@@ -43,7 +43,10 @@ describe('Feathers application tests', () => {
     it('shows a 404 JSON error without stack trace', () => {
       return rp({
         url: getUrl('path/to/nowhere'),
-        json: true
+        json: true,
+        headers: {
+          'Accept': 'application/json'
+        }
       }).catch(res => {
         assert.equal(res.statusCode, 404);
         assert.equal(res.error.code, 404);


### PR DESCRIPTION
`json: true` does not set the proper `Accept` header, so we need to set it.