### PR TITLE
Exclude route parameters when generating services in nested folders

### DIFF
--- a/generators/service/index.js
+++ b/generators/service/index.js
@@ -87,7 +87,10 @@ module.exports = class ServiceGenerator extends Generator {
     ];
 
     return this.prompt(prompts).then(answers => {
-      const parts = (answers.name || props.name).split('/');
+      const parts = (answers.name || props.name)
+        .split('/')
+        // exclude route parameters from folder hierarchy i.e. /users/:id/roles 
+        .filter(part => !part.startsWith(':'));
       const name = parts.pop();
 
       this.props = Object.assign({


### PR DESCRIPTION
My team has really enjoyed the recently added ability to generate services in nested folders via the CLI. One gotcha is that when generating a service that includes route parameters (i.e. `/users/:id/roles`) the route parameters are included in the directory hierarchy:

```
users
|___ :id
	|___ roles
```

This pull request simply filters out any path part the begins with the ':' character, resulting in the following:

```
users
|___ roles
```