### PR TITLE
Remove space for consistent formatting

### DIFF
--- a/generators/app/templates/src/hooks/log.js
+++ b/generators/app/templates/src/hooks/log.js
@@ -17,7 +17,7 @@ module.exports = function () {
       logger.debug('Hook Context', util.inspect(context, {colors: false}));
     }
     
-    if (context.error) {
+    if(context.error) {
       logger.error(context.error.stack);
     }
   };


### PR DESCRIPTION
Elsewhere including this file there is no space e.g. "if(" i.e. between "if" and opening parenthesis