### PR TITLE
Use new url parser

### DIFF
--- a/generators/connection/templates/mongoose.js
+++ b/generators/connection/templates/mongoose.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 
 module.exports = function (app) {
-  mongoose.connect(app.get('mongodb'), {});
+  mongoose.connect(app.get('mongodb'), { useNewUrlParser: true });
   mongoose.Promise = global.Promise;
 
   app.set('mongooseClient', mongoose);


### PR DESCRIPTION
Currently it issues the following warning:
(node:6686) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.