### PR TITLE
Support sequelize connection object (#388)

### DIFF
--- a/generators/connection/templates/sequelize.js
+++ b/generators/connection/templates/sequelize.js
@@ -38,15 +38,35 @@ const operatorsAliases = {
 };
 
 module.exports = function (app) {
-  const connectionString = app.get('<%= database %>');
-  const sequelize = new Sequelize(connectionString, {
+  const connection = app.get('<%= database %>');
+  const connectionOptions = {
     dialect: '<%= database %>',
     logging: false,
     operatorsAliases,
     define: {
       freezeTableName: true
     }
-  });
+  };
+  let sequelize;
+
+  if (typeof connection === 'string') {
+    sequelize = new Sequelize(connection, connectionOptions);
+  }
+  else {
+    connectionOptions.host = connection.host || connection.hostname;
+
+    if (connection.port) {
+      connectionOptions.port = connection.port;
+    }
+
+    sequelize = new Sequelize(
+      connection.database,
+      connection.username,
+      connection.password,
+      connectionOptions
+    );
+  }
+
   const oldSetup = app.setup;
 
   app.set('sequelizeClient', sequelize);

--- a/test/generators.test.js
+++ b/test/generators.test.js
@@ -195,6 +195,38 @@ describe('generator-feathers', function() {
           )
         ).then(() => runTest('starts and shows the index page'));
       });
+
+      it('sequelize w/ connection object instead of string', () => {
+        const databaseName = 'dbname';
+        const databasePort = '5432';
+        const databaseHostname = '127.0.0.1';
+        const databaseUsername = 'user';
+        const databasePassword = 'password';
+        const connectionObject = {
+          username: databaseUsername,
+          password: databasePassword,
+          hostname: databaseHostname,
+          port: databasePort,
+          database: databaseName,
+        };
+
+        return runConnectionGenerator({
+          database: 'postgres',
+          adapter: 'sequelize',
+          connectionStyle: 'connectionObject',
+          databaseName,
+          databasePort,
+          databaseHostname,
+          databaseUsername,
+          databasePassword
+        }).then(() =>
+          assert.jsonFileContent(
+            path.join(appDir, 'config', 'default.json'), {
+              postgres: connectionObject
+            }
+          )
+        ).then(() => runTest('starts and shows the index page'));
+      });
     });
 
     it('rethinkdb', () => {


### PR DESCRIPTION
- generate app
  - npm i feathers-cli
  - npm link generator-feathers
  - npx feathers generate app
- generate postgrs `/src/sequelize.js`
  - npm i feathers-cli
  - npm link generator-feathers
  - npx feathers generate connection  #postgres
  - vim `config/default.json` # make postgres attribute an object
  - npx feathers generate service
    - curl new service :+1:
  - npx feathers generate service
    - `config/default.json` isn't molested 👍 
- generate mysql `/src/sequelize.js`
  - npm link generator-feathers
  - npx feathers generate connection  #mysql
    - new template in effect :+1:

Resolves #388 