### PR TITLE
The logger makes swallowing errors confusing

### DIFF
--- a/generators/app/templates/src/hooks/log.js
+++ b/generators/app/templates/src/hooks/log.js
@@ -17,7 +17,7 @@ module.exports = function () {
       logger.debug('Hook Context', util.inspect(context, {colors: false}));
     }
     
-    if(context.error) {
+    if(context.error && !context.result) {
       logger.error(context.error.stack);
     }
   };


### PR DESCRIPTION
When you swallow an error you expect silence... this common built in hook makes it noisy regardless. It looks almost exactly like an uncaught error and is very deceiving