### PR TITLE
Security update: ensure nodemon^1.18.7

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -26,7 +26,7 @@ module.exports = class AppGenerator extends Generator {
     ];
 
     this.devDependencies = [
-      'nodemon',
+      'nodemon@^1.18.7',
       'eslint',
       'request',
       'request-promise'


### PR DESCRIPTION
A [critical security issue](https://www.npmjs.com/advisories/737) with [`flatmap-stream`](https://www.npmjs.com/package/flatmap-stream) was [traced to a sub-debpendency of `nodemon`](https://github.com/remy/nodemon/issues/1451). This is [fixed in `nodemon@1.18.7`](https://github.com/remy/nodemon/releases/tag/v1.18.7). I realize that `nodemon` is only a `devDependency` that is installed when you `feathers generate app` so it shouldn't affect production apps, and that since no version is currently specified it **_should_** get the latest version (which is fixed). However, I just updated my global `@feathersjs/cli` and ran `feathers generate app` and it installed `nodemon@1.18.6` which still contained the vulnerability.

For the time being, it seems wise to specify `nodemon@^1.18.7` in the app generator just to make sure people don't inadvertently get the malicious code on their systems. This can probably be removed in the near future, but I don't think it could hurt to make this the minimum version, for now.