### PR TITLE
If mongoose can't connect, the process is unhealthy and should termin…

### DIFF
--- a/generators/connection/templates/mongoose.js
+++ b/generators/connection/templates/mongoose.js
@@ -1,10 +1,15 @@
 const mongoose = require('mongoose');
+const logger = require('./logger');
 
 module.exports = function (app) {
   mongoose.connect(
     app.get('mongodb'),
     { useCreateIndex: true, useNewUrlParser: true }
-  );
+  ).catch(err => {
+    logger.error(err);
+    process.exit(1);
+  });
+  
   mongoose.Promise = global.Promise;
 
   app.set('mongooseClient', mongoose);


### PR DESCRIPTION
…ate by default.  This is appropriate for a Docker container and development.  Mongoose doesn't appear to attempt to reconnect later, so the process should throw a fatal error.  

This is related to https://github.com/feathersjs/feathers/issues/1385

It's a workaround for whatever issue is causing Feathers to not respond when Mongoose is unavailable.  It's generated code so can be customized.

I looked at the mongodb.js connector, but it may attempt to reconnect.  I'm not using it, so I'm not sure what is most helpful in that case.

Thanks!

Michael