### PR TITLE
Bumps lighthouse accessibility score

### DIFF
--- a/generators/app/templates/js/app.test.mocha.js
+++ b/generators/app/templates/js/app.test.mocha.js
@@ -23,7 +23,7 @@ describe('Feathers application tests', () => {
 
   it('starts and shows the index page', () => {
     return rp(getUrl()).then(body =>
-      assert.ok(body.indexOf('<html>') !== -1)
+      assert.ok(body.indexOf('<html lang="en">') !== -1)
     );
   });
 

--- a/generators/app/templates/js/static/public/index.html
+++ b/generators/app/templates/js/static/public/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <title>Welcome to Feathers</title>
     <style>


### PR DESCRIPTION
I accidentally ran Lighthouse against the index and was suggested to add `lang="en"` to increase the accessibility score, results shown below. If this is accepted I might take a look at the other suggestions as well.

![image](https://user-images.githubusercontent.com/230500/61002089-2639fb00-a361-11e9-9586-78b5972d0eeb.png)
