### PR TITLE
Start git-ignoring .vscode/settings.json

### DIFF
--- a/generators/app/templates/js/_gitignore
+++ b/generators/app/templates/js/_gitignore
@@ -38,7 +38,6 @@ node_modules
 
 # IDE - VSCode
 .vscode/*
-!.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json


### PR DESCRIPTION
This file should be git-ignored as it is intended for (and may contain) user specific settings. For example, VSCode extensions usually store user-preferences in this file so we don't want to commit them to the repository.

Since we are not distributing the `settings.json` file with the generator this change should be harmless but will improve the user experience for VSCode users (not being surprised by `.vscode`  entries appearing in their git status).