### PR TITLE
Fix duplicate extension for app hook generator

### DIFF
--- a/generators/hook/index.js
+++ b/generators/hook/index.js
@@ -74,7 +74,7 @@ module.exports = class HookGenerator extends Generator {
     let moduleName = relativeRoot + hookName;
 
     if (serviceName === '__app') {
-      hooksFile = this.srcDestinationPath(this.libDirectory, 'app.hooks.ts');
+      hooksFile = this.srcDestinationPath(this.libDirectory, 'app.hooks');
       moduleName = `./${hookName}`;
     }
 


### PR DESCRIPTION
A fix for a bug where application-wide hook is written to app.hook.ts.* instead of app.hook.*