### PR TITLE
Add packager version in choices value

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -86,8 +86,8 @@ module.exports = class AppGenerator extends Generator {
       message: 'Which package manager are you using (has to be installed globally)?',
       default: 'npm',
       choices: [
-        { name: 'npm', value: 'npm'   },
-        { name: 'Yarn', value: 'yarn' }
+        { name: 'npm', value: 'npm@>= 3.0.0'   },
+        { name: 'Yarn', value: 'yarn@>= 0.18.0' }
       ]
     }, {
       type: 'checkbox',


### PR DESCRIPTION
without version string, _packagerInstall in lib/generator.js will always use npm though yarn selected, because there is no entry in package.json engines field (version undefined)