### PR TITLE
refactor: use app.interface.ts instead of declarations.d.ts

### DIFF
--- a/generators/app/templates/ts/app.ts
+++ b/generators/app/templates/ts/app.ts
@@ -10,7 +10,7 @@ import express from '@feathersjs/express';
 <% if (hasProvider('socketio')) { %>import socketio from '@feathersjs/socketio';<% } %>
 <% if (hasProvider('primus')) { %>import primus from '@feathersjs/primus';<% } %>
 
-import { Application } from './declarations';
+import { Application } from './app.interface';
 import logger from './logger';
 import middleware from './middleware';
 import services from './services';

--- a/generators/app/templates/ts/src/app.interface.ts
+++ b/generators/app/templates/ts/src/app.interface.ts
@@ -1,8 +1,10 @@
-import { Application as ExpressFeathers } from '@feathersjs/express';
 import { Service } from '@feathersjs/feathers';
+import { Application as ExpressFeathers } from '@feathersjs/express';
 import '@feathersjs/transport-commons';
+// Don't remove this comment. It's needed to format import lines nicely.
 
 // A mapping of service names to types. Will be extended in service files.
-export interface ServiceTypes {}
+export interface ServiceTypes {
+}
 // The application instance type that will be used everywhere else
 export type Application = ExpressFeathers<ServiceTypes>;

--- a/generators/app/templates/ts/src/channels.ts
+++ b/generators/app/templates/ts/src/channels.ts
@@ -1,5 +1,5 @@
 import { HookContext } from '@feathersjs/feathers';
-import { Application } from './declarations';
+import { Application } from './app.interface';
 
 export default function(app: Application) {
   if(typeof app.channel !== 'function') {

--- a/generators/app/templates/ts/src/middleware/index.ts
+++ b/generators/app/templates/ts/src/middleware/index.ts
@@ -1,4 +1,4 @@
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 // Don't remove this comment. It's needed to format import lines nicely.
 
 export default function (app: Application) {

--- a/generators/app/templates/ts/src/services/index.ts
+++ b/generators/app/templates/ts/src/services/index.ts
@@ -1,4 +1,4 @@
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 // Don't remove this comment. It's needed to format import lines nicely.
 
 export default function (app: Application) {

--- a/generators/authentication/templates/ts/authentication.ts
+++ b/generators/authentication/templates/ts/authentication.ts
@@ -1,15 +1,8 @@
-import { ServiceAddons } from '@feathersjs/feathers';
 import { AuthenticationService, JWTStrategy } from '@feathersjs/authentication';
 import { LocalStrategy } from '@feathersjs/authentication-local';
 import { expressOauth } from '@feathersjs/authentication-oauth';
 
-import { Application } from './declarations';
-
-declare module './declarations' {
-  interface ServiceTypes {
-    'authentication': AuthenticationService & ServiceAddons<any>;
-  }
-}
+import { Application } from './app.interface';
 
 export default function(app: Application) {
   const authentication = new AuthenticationService(app);

--- a/generators/connection/templates/ts/cassandra.ts
+++ b/generators/connection/templates/ts/cassandra.ts
@@ -1,6 +1,6 @@
 import ExpressCassandra from 'express-cassandra';
 import FeathersCassandra from 'feathers-cassandra';
-import { Application } from './declarations';
+import { Application } from './app.interface';
 
 export default function (app: Application) {
   const connectionInfo = app.get('<%= database %>');

--- a/generators/connection/templates/ts/knex.ts
+++ b/generators/connection/templates/ts/knex.ts
@@ -1,5 +1,5 @@
 import knex from 'knex';
-import { Application } from './declarations';
+import { Application } from './app.interface';
 
 export default function (app: Application) {
   const { client, connection } = app.get('<%= database %>');

--- a/generators/connection/templates/ts/mongodb.ts
+++ b/generators/connection/templates/ts/mongodb.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import { parseConnectionString as parse } from 'mongodb-core';
 import { MongoClient } from 'mongodb';
-import { Application } from './declarations';
+import { Application } from './app.interface';
 const logger = require('./logger');
 
 export default function (app: Application) {

--- a/generators/connection/templates/ts/mongoose.ts
+++ b/generators/connection/templates/ts/mongoose.ts
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { Application } from './declarations';
+import { Application } from './app.interface';
 import logger from './logger';
 
 export default function (app: Application) {

--- a/generators/connection/templates/ts/objection.ts
+++ b/generators/connection/templates/ts/objection.ts
@@ -1,5 +1,5 @@
 const { Model } = require('objection');
-import { Application } from './declarations';
+import { Application } from './app.interface';
 
 export default function (app: Application) {
   const { client, connection } = app.get('<%= database %>');

--- a/generators/connection/templates/ts/sequelize-mssql.ts
+++ b/generators/connection/templates/ts/sequelize-mssql.ts
@@ -1,6 +1,6 @@
 import url from 'url';
 import Sequelize from 'sequelize';
-import { Application } from './declarations';
+import { Application } from './app.interface';
 
 export default function (app: Application) {
   const connectionString = app.get('mssql');

--- a/generators/connection/templates/ts/sequelize.ts
+++ b/generators/connection/templates/ts/sequelize.ts
@@ -1,5 +1,5 @@
 import { Sequelize } from 'sequelize';
-import { Application } from './declarations';
+import { Application } from './app.interface';
 
 export default function (app: Application) {
   const connectionString = app.get('<%= database %>');

--- a/generators/service/templates/ts/model/cassandra-user.ts
+++ b/generators/service/templates/ts/model/cassandra-user.ts
@@ -1,6 +1,6 @@
 // See https://express-cassandra.readthedocs.io/en/latest/schema/
 // for more of what you can do here.
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 
 export default function (app: Application) {
   const models = app.get('models');

--- a/generators/service/templates/ts/model/cassandra.ts
+++ b/generators/service/templates/ts/model/cassandra.ts
@@ -1,6 +1,6 @@
 // See https://express-cassandra.readthedocs.io/en/latest/schema/
 // for more of what you can do here.
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 
 export default function (app: Application) {
   const models = app.get('models');

--- a/generators/service/templates/ts/model/knex-user.ts
+++ b/generators/service/templates/ts/model/knex-user.ts
@@ -2,7 +2,7 @@
 // 
 // See http://knexjs.org/
 // for more of what you can do here.
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 import Knex from 'knex';
 
 export default function (app: Application) {

--- a/generators/service/templates/ts/model/knex.ts
+++ b/generators/service/templates/ts/model/knex.ts
@@ -3,7 +3,7 @@
 // See http://knexjs.org/
 // for more of what you can do here.
 import Knex from 'knex';
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 
 export default function (app: Application) {
   const db: Knex = app.get('knexClient');

--- a/generators/service/templates/ts/model/mongoose-user.ts
+++ b/generators/service/templates/ts/model/mongoose-user.ts
@@ -2,7 +2,7 @@
 //
 // See http://mongoosejs.com/docs/models.html
 // for more of what you can do here.
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 
 export default function (app: Application) {
   const mongooseClient = app.get('mongooseClient');

--- a/generators/service/templates/ts/model/mongoose.ts
+++ b/generators/service/templates/ts/model/mongoose.ts
@@ -2,7 +2,7 @@
 // 
 // See http://mongoosejs.com/docs/models.html
 // for more of what you can do here.
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 
 export default function (app: Application) {
   const mongooseClient = app.get('mongooseClient');

--- a/generators/service/templates/ts/model/nedb-user.ts
+++ b/generators/service/templates/ts/model/nedb-user.ts
@@ -1,6 +1,6 @@
 import NeDB from 'nedb';
 import path from 'path';
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 
 export default function (app: Application) {
   const dbPath = app.get('nedb');

--- a/generators/service/templates/ts/model/nedb.ts
+++ b/generators/service/templates/ts/model/nedb.ts
@@ -1,6 +1,6 @@
 import NeDB from 'nedb';
 import path from 'path';
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 
 export default function (app: Application) {
   const dbPath = app.get('nedb');

--- a/generators/service/templates/ts/model/objection-user.ts
+++ b/generators/service/templates/ts/model/objection-user.ts
@@ -2,7 +2,7 @@
 // for more of what you can do here.
 import { Model } from 'objection';
 import Knex from 'knex';
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 
 class <%= camelName %> extends Model {
   createdAt!: string;

--- a/generators/service/templates/ts/model/objection.ts
+++ b/generators/service/templates/ts/model/objection.ts
@@ -2,7 +2,7 @@
 // for more of what you can do here.
 import { Model } from 'objection';
 import Knex from 'knex';
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 
 class <%= camelName %> extends Model {
   createdAt!: string;

--- a/generators/service/templates/ts/model/sequelize-user.ts
+++ b/generators/service/templates/ts/model/sequelize-user.ts
@@ -1,7 +1,7 @@
 // See http://docs.sequelizejs.com/en/latest/docs/models-definition/
 // for more of what you can do here.
 import { Sequelize, DataTypes } from 'sequelize';
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 
 export default function (app: Application) {
   const sequelizeClient: Sequelize = app.get('sequelizeClient');

--- a/generators/service/templates/ts/model/sequelize.ts
+++ b/generators/service/templates/ts/model/sequelize.ts
@@ -1,7 +1,7 @@
 // See http://docs.sequelizejs.com/en/latest/docs/models-definition/
 // for more of what you can do here.
 import { Sequelize, DataTypes } from 'sequelize';
-import { Application } from '../declarations';
+import { Application } from '../app.interface';
 
 export default function (app: Application) {
   const sequelizeClient: Sequelize = app.get('sequelizeClient');

--- a/generators/service/templates/ts/service.ts
+++ b/generators/service/templates/ts/service.ts
@@ -1,16 +1,8 @@
 // Initializes the `<%= name %>` service on path `/<%= path %>`
-import { ServiceAddons } from '@feathersjs/feathers';
-import { Application } from '<%= relativeRoot %>declarations';
+import { Application } from '<%= relativeRoot %>app.interface';
 import { <%= className %> } from './<%= kebabName %>.class';<% if(modelName) { %>
 import createModel from '<%= relativeRoot %>models/<%= modelName %>';<% } %>
 import hooks from './<%= kebabName %>.hooks';
-
-// Add this service to the service type index
-declare module '<%= relativeRoot %>declarations' {
-  interface ServiceTypes {
-    '<%= path %>': <%= className %> & ServiceAddons<any>;
-  }
-}
 
 export default function (app: Application) {
   <% if (modelName) { %>const Model = createModel(app);<% } %>

--- a/generators/service/templates/ts/types/generic.ts
+++ b/generators/service/templates/ts/types/generic.ts
@@ -1,5 +1,5 @@
 import { Id, NullableId, Paginated, Params, ServiceMethods } from '@feathersjs/feathers';
-import { Application } from '<%= relativeRoot %>declarations';
+import { Application } from '<%= relativeRoot %>app.interface';
 
 interface Data {}
 

--- a/generators/service/templates/ts/types/knex.ts
+++ b/generators/service/templates/ts/types/knex.ts
@@ -1,5 +1,5 @@
 import { Service, KnexServiceOptions } from 'feathers-knex';
-import { Application } from '<%= relativeRoot %>declarations';
+import { Application } from '<%= relativeRoot %>app.interface';
 
 export class <%= className %> extends Service {
   constructor(options: Partial<KnexServiceOptions>, app: Application) {

--- a/generators/service/templates/ts/types/memory.ts
+++ b/generators/service/templates/ts/types/memory.ts
@@ -1,5 +1,5 @@
 import { Service, MemoryServiceOptions } from 'feathers-memory';
-import { Application } from '<%= relativeRoot %>declarations';
+import { Application } from '<%= relativeRoot %>app.interface';
 
 export class <%= className %> extends Service {
   constructor(options: Partial<MemoryServiceOptions>, app: Application) {

--- a/generators/service/templates/ts/types/mongodb.ts
+++ b/generators/service/templates/ts/types/mongodb.ts
@@ -1,6 +1,6 @@
 import { Db } from 'mongodb';
 import { Service, MongoDBServiceOptions } from 'feathers-mongodb';
-import { Application } from '<%= relativeRoot %>declarations';
+import { Application } from '<%= relativeRoot %>app.interface';
 
 export class <%= className %> extends Service {
   constructor(options: Partial<MongoDBServiceOptions>, app: Application) {

--- a/generators/service/templates/ts/types/mongoose.ts
+++ b/generators/service/templates/ts/types/mongoose.ts
@@ -1,5 +1,5 @@
 import { Service, MongooseServiceOptions } from 'feathers-mongoose';
-import { Application } from '<%= relativeRoot %>declarations';
+import { Application } from '<%= relativeRoot %>app.interface';
 
 export class <%= className %> extends Service {
   constructor(options: Partial<MongooseServiceOptions>, app: Application) {

--- a/generators/service/templates/ts/types/nedb.ts
+++ b/generators/service/templates/ts/types/nedb.ts
@@ -1,5 +1,5 @@
 import { Service, NedbServiceOptions } from 'feathers-nedb';
-import { Application } from '<%= relativeRoot %>declarations';
+import { Application } from '<%= relativeRoot %>app.interface';
 
 export class <%= className %> extends Service {
   constructor(options: Partial<NedbServiceOptions>, app: Application) {

--- a/generators/service/templates/ts/types/sequelize.ts
+++ b/generators/service/templates/ts/types/sequelize.ts
@@ -1,5 +1,5 @@
 import { Service, SequelizeServiceOptions } from 'feathers-sequelize';
-import { Application } from '<%= relativeRoot %>declarations';
+import { Application } from '<%= relativeRoot %>app.interface';
 
 export class <%= className %> extends Service {
   constructor(options: Partial<SequelizeServiceOptions>, app: Application) {

--- a/generators/upgrade/templates/ts/authentication.ts
+++ b/generators/upgrade/templates/ts/authentication.ts
@@ -1,4 +1,4 @@
-import { Application } from '../../declarations';
+import { Application } from '../../app.interface';
 import { AuthenticationService, JWTStrategy } from '@feathersjs/authentication';
 import { LocalStrategy } from '@feathersjs/authentication-local';
 import { expressOauth } from '@feathersjs/authentication-oauth';


### PR DESCRIPTION
- remove declarations.d.ts (it should be only for global types or untyped npm libraries)
- remove module declaration merge code in service.ts files (declare module '../declarations.d.ts')
- use app.interface.ts for Application type and ServiceTypes type (similar to feathers-plus did)
- automatically import service class and insert related ServiceType when generate authentication or generate service in app.interface.ts