### PR TITLE
fix: create test.json when generate app

### DIFF
--- a/generators/app/configs/config.test.json.js
+++ b/generators/app/configs/config.test.json.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return {};
+};

--- a/generators/app/configs/index.js
+++ b/generators/app/configs/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   configDefault: require('./config.default.json.js'),
   configProduction: require('./config.production.json.js'),
+  configTest: require('./config.test.json.js'),
   package: require('./package.json.js'),
   eslintrc: require('./eslintrc.json.js'),
   tsconfig: require('./tsconfig.json.js')

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -196,6 +196,11 @@ module.exports = class AppGenerator extends Generator {
       makeConfig.configProduction(this)
     );
 
+    this.fs.writeJSON(
+      this.destinationPath(this.configDirectory, 'test.json'),
+      makeConfig.configTest(this)
+    );
+
     if (props.authentication) {
       // Create the users service
       this.composeWith(require.resolve('../authentication'), {


### PR DESCRIPTION
without NODE_ENV=, tested codes (config) will search for config/test.json because jest will provide NODE_ENV=test by default