### PR TITLE
Use package.json to dettermine language

### DIFF
--- a/generators/app/configs/package.json.js
+++ b/generators/app/configs/package.json.js
@@ -55,6 +55,7 @@ module.exports = function(generator) {
       test: `${packager} run compile && ${packager} run ${props.tester}`,
       start: `${packager} run compile && node lib/`
     };
+    pkg.types = 'lib/';
 
     delete pkg.scripts.eslint;
   }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -54,8 +54,15 @@ module.exports = class BaseGenerator extends Generator {
 
   get isTypescript () {
     const pkg = this.fs.readJSON(this.destinationPath('package.json'));
-    const hasTS = (pkg.devDependencies && pkg.devDependencies.typescript) ||
-      (pkg.dependencies && pkg.dependencies.typescript);
+    const configFile = this.destinationPath('config', 'default.json');
+
+    let hasTS = pkg && pkg.types;
+
+    if (!hasTS && this.fs.exists(configFile)) {
+      const config = this.fs.readJSON(configFile);
+
+      hasTS = config && config.ts;
+    }
 
     return hasTS || (this.props.language === 'ts');
   }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -53,9 +53,11 @@ module.exports = class BaseGenerator extends Generator {
   }
 
   get isTypescript () {
-    const config = this.fs.readJSON(this.destinationPath('config', 'default.json'));
+    const pkg = this.fs.readJSON(this.destinationPath('package.json'));
+    const hasTS = (pkg.devDependencies && pkg.devDependencies.typescript) ||
+      (pkg.dependencies && pkg.dependencies.typescript);
 
-    return (config && config.ts) || (this.props.language === 'ts');
+    return hasTS || (this.props.language === 'ts');
   }
   
   get srcType () {


### PR DESCRIPTION
Add the information if TypeScript is used into the `package.json` instead of using the configuration. Should also still be backwards compatible.

- Closes https://github.com/feathersjs/generator-feathers/issues/470
- Closes https://github.com/feathersjs/cli/issues/190