### PR TITLE
Fixes app ignoring configured hostname

### DIFF
--- a/generators/app/templates/js/app.test.jest.js
+++ b/generators/app/templates/js/app.test.jest.js
@@ -2,10 +2,11 @@ const axios = require('axios');
 const url = require('url');
 const app = require('../<%= src %>/app');
 
+const hostname = app.get('host') || 'localhost';
 const port = app.get('port') || 8998;
 const getUrl = pathname => url.format({
-  hostname: app.get('host') || 'localhost',
   protocol: 'http',
+  hostname,
   port,
   pathname
 });
@@ -14,7 +15,7 @@ describe('Feathers application tests (with jest)', () => {
   let server;
 
   beforeAll(done => {
-    server = app.listen(port);
+    server = app.listen(port, hostname);
     server.once('listening', () => done());
   });
 

--- a/generators/app/templates/js/app.test.mocha.js
+++ b/generators/app/templates/js/app.test.mocha.js
@@ -3,10 +3,11 @@ const axios = require('axios');
 const url = require('url');
 const app = require('../<%= src %>/app');
 
+const hostname= app.get('host') || 'localhost';
 const port = app.get('port') || 8998;
 const getUrl = pathname => url.format({
-  hostname: app.get('host') || 'localhost',
   protocol: 'http',
+  hostname,
   port,
   pathname
 });
@@ -15,7 +16,7 @@ describe('Feathers application tests', () => {
   let server;
 
   before(function(done) {
-    server = app.listen(port);
+    server = app.listen(port, hostname);
     server.once('listening', () => done());
   });
 

--- a/generators/app/templates/js/src/index.js
+++ b/generators/app/templates/js/src/index.js
@@ -1,13 +1,14 @@
 /* eslint-disable no-console */
 const logger = require('./logger');
 const app = require('./app');
+const hostname = app.get('host');
 const port = app.get('port');
-const server = app.listen(port);
+const server = app.listen(port, hostname);
 
 process.on('unhandledRejection', (reason, p) =>
   logger.error('Unhandled Rejection at: Promise ', p, reason)
 );
 
 server.on('listening', () =>
-  logger.info('Feathers application started on http://%s:%d', app.get('host'), port)
+  logger.info('Feathers application started on http://%s:%d', hostname, port)
 );

--- a/generators/app/templates/ts/app.test.jest.ts
+++ b/generators/app/templates/ts/app.test.jest.ts
@@ -5,10 +5,11 @@ import axios from 'axios';
 
 import app from '../<%= src %>/app';
 
+const hostname = app.get('host') || 'localhost';
 const port = app.get('port') || 8998;
 const getUrl = (pathname?: string) => url.format({
-  hostname: app.get('host') || 'localhost',
   protocol: 'http',
+  hostname,
   port,
   pathname
 });
@@ -17,7 +18,7 @@ describe('Feathers application tests (with jest)', () => {
   let server: Server;
 
   beforeAll(done => {
-    server = app.listen(port);
+    server = app.listen(port, hostname);
     server.once('listening', () => done());
   });
 

--- a/generators/app/templates/ts/app.test.mocha.ts
+++ b/generators/app/templates/ts/app.test.mocha.ts
@@ -5,10 +5,11 @@ import axios from 'axios';
 
 import app from '../<%= src %>/app';
 
+const hostname = app.get('host') || 'localhost';
 const port = app.get('port') || 8998;
 const getUrl = (pathname?: string) => url.format({
-  hostname: app.get('host') || 'localhost',
   protocol: 'http',
+  hostname,
   port,
   pathname
 });
@@ -17,7 +18,7 @@ describe('Feathers application tests', () => {
   let server: Server;
 
   before(function(done) {
-    server = app.listen(port);
+    server = app.listen(port, hostname);
     server.once('listening', () => done());
   });
 

--- a/generators/app/templates/ts/src/index.ts
+++ b/generators/app/templates/ts/src/index.ts
@@ -1,13 +1,14 @@
 import logger from './logger';
 import app from './app';
 
+const hostname = app.get('host');
 const port = app.get('port');
-const server = app.listen(port);
+const server = app.listen(port, hostname);
 
 process.on('unhandledRejection', (reason, p) =>
   logger.error('Unhandled Rejection at: Promise ', p, reason)
 );
 
 server.on('listening', () =>
-  logger.info('Feathers application started on http://%s:%d', app.get('host'), port)
+  logger.info('Feathers application started on http://%s:%d', hostname, port)
 );


### PR DESCRIPTION
By default the app listens on all available interfaces, ignoring the configured hostname