### PR TITLE
Replaced string 'user' with the service name for mongoDB collection

### DIFF
--- a/generators/service/templates/ts/types/mongodb.ts
+++ b/generators/service/templates/ts/types/mongodb.ts
@@ -5,11 +5,11 @@ import { Application } from '<%= relativeRoot %>declarations';
 export class <%= className %> extends Service {
   constructor(options: Partial<MongoDBServiceOptions>, app: Application) {
     super(options);
-    
+
     const client: Promise<Db> = app.get('mongoClient');
-    
+
     client.then(db => {
-      this.Model = db. collection('users');
+      this.Model = db.collection('<%= kebabName %>');
     });
   }
 };


### PR DESCRIPTION
The Typescript service generator for MongoDB had 'users' hard-coded for the collection name. I changed it to match the JS generator, using the service's kebabName.

