### PR TITLE
Revert "Fixes app not listening to configured hostname (#495)"

### DIFF
--- a/generators/app/templates/js/app.test.jest.js
+++ b/generators/app/templates/js/app.test.jest.js
@@ -2,11 +2,10 @@ const axios = require('axios');
 const url = require('url');
 const app = require('../<%= src %>/app');
 
-const hostname = app.get('host') || 'localhost';
 const port = app.get('port') || 8998;
 const getUrl = pathname => url.format({
+  hostname: app.get('host') || 'localhost',
   protocol: 'http',
-  hostname,
   port,
   pathname
 });
@@ -15,7 +14,7 @@ describe('Feathers application tests (with jest)', () => {
   let server;
 
   beforeAll(done => {
-    server = app.listen(port, hostname);
+    server = app.listen(port);
     server.once('listening', () => done());
   });
 

--- a/generators/app/templates/js/app.test.mocha.js
+++ b/generators/app/templates/js/app.test.mocha.js
@@ -3,11 +3,10 @@ const axios = require('axios');
 const url = require('url');
 const app = require('../<%= src %>/app');
 
-const hostname= app.get('host') || 'localhost';
 const port = app.get('port') || 8998;
 const getUrl = pathname => url.format({
+  hostname: app.get('host') || 'localhost',
   protocol: 'http',
-  hostname,
   port,
   pathname
 });
@@ -16,7 +15,7 @@ describe('Feathers application tests', () => {
   let server;
 
   before(function(done) {
-    server = app.listen(port, hostname);
+    server = app.listen(port);
     server.once('listening', () => done());
   });
 

--- a/generators/app/templates/js/src/index.js
+++ b/generators/app/templates/js/src/index.js
@@ -1,14 +1,13 @@
 /* eslint-disable no-console */
 const logger = require('./logger');
 const app = require('./app');
-const hostname = app.get('host');
 const port = app.get('port');
-const server = app.listen(port, hostname);
+const server = app.listen(port);
 
 process.on('unhandledRejection', (reason, p) =>
   logger.error('Unhandled Rejection at: Promise ', p, reason)
 );
 
 server.on('listening', () =>
-  logger.info('Feathers application started on http://%s:%d', hostname, port)
+  logger.info('Feathers application started on http://%s:%d', app.get('host'), port)
 );

--- a/generators/app/templates/ts/app.test.jest.ts
+++ b/generators/app/templates/ts/app.test.jest.ts
@@ -5,11 +5,10 @@ import axios from 'axios';
 
 import app from '../<%= src %>/app';
 
-const hostname = app.get('host') || 'localhost';
 const port = app.get('port') || 8998;
 const getUrl = (pathname?: string) => url.format({
+  hostname: app.get('host') || 'localhost',
   protocol: 'http',
-  hostname,
   port,
   pathname
 });
@@ -18,7 +17,7 @@ describe('Feathers application tests (with jest)', () => {
   let server: Server;
 
   beforeAll(done => {
-    server = app.listen(port, hostname);
+    server = app.listen(port);
     server.once('listening', () => done());
   });
 

--- a/generators/app/templates/ts/app.test.mocha.ts
+++ b/generators/app/templates/ts/app.test.mocha.ts
@@ -5,11 +5,10 @@ import axios from 'axios';
 
 import app from '../<%= src %>/app';
 
-const hostname = app.get('host') || 'localhost';
 const port = app.get('port') || 8998;
 const getUrl = (pathname?: string) => url.format({
+  hostname: app.get('host') || 'localhost',
   protocol: 'http',
-  hostname,
   port,
   pathname
 });
@@ -18,7 +17,7 @@ describe('Feathers application tests', () => {
   let server: Server;
 
   before(function(done) {
-    server = app.listen(port, hostname);
+    server = app.listen(port);
     server.once('listening', () => done());
   });
 

--- a/generators/app/templates/ts/src/index.ts
+++ b/generators/app/templates/ts/src/index.ts
@@ -1,14 +1,13 @@
 import logger from './logger';
 import app from './app';
 
-const hostname = app.get('host');
 const port = app.get('port');
-const server = app.listen(port, hostname);
+const server = app.listen(port);
 
 process.on('unhandledRejection', (reason, p) =>
   logger.error('Unhandled Rejection at: Promise ', p, reason)
 );
 
 server.on('listening', () =>
-  logger.info('Feathers application started on http://%s:%d', hostname, port)
+  logger.info('Feathers application started on http://%s:%d', app.get('host'), port)
 );


### PR DESCRIPTION
This reverts #495 for now because there were many follow-up issues with generated applications not listening on Docker containers (e.g. [here](https://stackoverflow.com/questions/59309125/node-docker-not-working-for-feathersjs-container-running-but-localhost-not-acc)) or cloud deployments (e.g. Azuer).