### PR TITLE
fix: set private field true in package.json

### DIFF
--- a/generators/app/configs/package.json.js
+++ b/generators/app/configs/package.json.js
@@ -14,6 +14,7 @@ module.exports = function(generator) {
     description: props.description,
     version: '0.0.0',
     homepage: '',
+    private: true,
     main: lib,
     keywords: [
       'feathers'


### PR DESCRIPTION
yarn is showing much of this warning when generating app:
`warning package.json: No license field`

we can to set private field true in package.json to prevent the warnings