### PR TITLE
Fix lint errors picked up by StandardJS

### DIFF
--- a/generators/app/templates/js/app.test.mocha.js
+++ b/generators/app/templates/js/app.test.mocha.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const axios = require('axios');
 const url = require('url');
 const app = require('../<%= src %>/app');

--- a/generators/authentication/templates/js/authentication.js
+++ b/generators/authentication/templates/js/authentication.js
@@ -1,12 +1,12 @@
 const { AuthenticationService, JWTStrategy } = require('@feathersjs/authentication');
-const { LocalStrategy } = require('@feathersjs/authentication-local');
+<% if(strategies.includes('local')) { %>const { LocalStrategy } = require('@feathersjs/authentication-local');<% } %>
 const { expressOauth } = require('@feathersjs/authentication-oauth');
 
 module.exports = app => {
   const authentication = new AuthenticationService(app);
 
   authentication.register('jwt', new JWTStrategy());
-  <% if(strategies.includes('local')) { %>authentication.register('local', new LocalStrategy());<% } %>
+<% if(strategies.includes('local')) { %>  authentication.register('local', new LocalStrategy());<% } %>
 
   app.use('/authentication', authentication);
   app.configure(expressOauth());

--- a/generators/service/templates/js/model/sequelize-user.js
+++ b/generators/service/templates/js/model/sequelize-user.js
@@ -18,7 +18,7 @@ module.exports = function (app) {
     },
   <% } %>
   <% authentication.oauthProviders.forEach(provider => { %>
-    <%= provider %>Id: { type: Sequelize.STRING },
+    <%= provider %>Id: { type: DataTypes.STRING },
   <% }); %>
   }, {
     hooks: {


### PR DESCRIPTION
### Fix lint errors picked up by StandardJS

Following #524 this fixes some lint errors I picked up by generating the project with StandardJS. I did this in a separate PR since #524 may undergo a longer review, while these fixes have no dependency on that PR and are just simple fixes.