### PR TITLE
Put MariaDB before MySQL

### DIFF
--- a/generators/connection/index.js
+++ b/generators/connection/index.js
@@ -180,7 +180,7 @@ module.exports = class ConnectionGenerator extends Generator {
         name: 'database',
         message: 'Which database are you connecting to?',
         choices: [
-          { name: 'MySQL (MariaDB)', value: 'mysql' },
+          { name: 'MariaDB (MySQL)', value: 'mysql' },
           { name: 'PostgreSQL', value: 'postgres' },
           { name: 'SQLite', value: 'sqlite' },
           { name: 'SQL Server', value: 'mssql' }


### PR DESCRIPTION
MariaDB has taken over for MySQL; therefore MariaDB probably should come first.