### PR TITLE
Export Application based hookcontext for autocompletion of services

### DIFF
--- a/generators/app/templates/ts/app.ts
+++ b/generators/app/templates/ts/app.ts
@@ -16,9 +16,11 @@ import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
 import channels from './channels';
+import { HookContext as FeathersHookContext } from '@feathersjs/feathers';
 // Don't remove this comment. It's needed to format import lines nicely.
 
 const app: Application = express(feathers());
+export type HookContext<T = any> = { app: Application } & FeathersHookContext<T>;
 
 // Load app configuration
 app.configure(configuration());


### PR DESCRIPTION
This helps with autocompleting the application


in your hooks you can do:

```TypeScript
(context: HookContext<User>) => {
  context.app.service('..
                       users
                       notifications
                       roles
}
```

So when you start typing it will give autocomplete based on `declarations.ts`
Though it would be recommended to add HookContext

In my app i added the HookContext in the import blacklist tslint rule like so:
```
    "import-blacklist": [
      true,
      { "@feathersjs/feathers": ["HookContext"] }
    ],
```

So you can only import hookContext of YOUR app and not the default one 