### PR TITLE
chore: remove mongoose.Promise

### DIFF
--- a/generators/connection/templates/js/mongoose.js
+++ b/generators/connection/templates/js/mongoose.js
@@ -9,8 +9,6 @@ module.exports = function (app) {
     logger.error(err);
     process.exit(1);
   });
-  
-  mongoose.Promise = global.Promise;
 
   app.set('mongooseClient', mongoose);
 };

--- a/generators/connection/templates/ts/mongoose.ts
+++ b/generators/connection/templates/ts/mongoose.ts
@@ -10,8 +10,6 @@ export default function (app: Application): void {
     logger.error(err);
     process.exit(1);
   });
-  
-  mongoose.Promise = global.Promise;
 
   app.set('mongooseClient', mongoose);
 }


### PR DESCRIPTION
Mongoose 5 (onwards) uses native promises by default, so no longer need to default `mongoose.Promise`, see https://masteringjs.io/tutorials/mongoose/promise