### PR TITLE
Configure a custom .eslintrc

### DIFF
--- a/generators/authentication/index.js
+++ b/generators/authentication/index.js
@@ -204,4 +204,8 @@ module.exports = class AuthGenerator extends Generator {
       this._packagerInstall(['@types/jsonwebtoken'], { saveDev: true });
     }
   }
+  
+  end () {
+    this._runLintIfAvailable();
+  }
 };

--- a/generators/connection/index.js
+++ b/generators/connection/index.js
@@ -366,6 +366,8 @@ module.exports = class ConnectionGenerator extends Generator {
   }
 
   end () {
+    this._runLintIfAvailable();
+    
     const { database, connectionString } = this.props;
 
     // NOTE (EK): If this is the first time we set this up

--- a/generators/hook/index.js
+++ b/generators/hook/index.js
@@ -195,4 +195,8 @@ module.exports = class HookGenerator extends Generator {
       mainFile, context
     );
   }
+  
+  end () {
+    this._runLintIfAvailable();
+  }
 };

--- a/generators/middleware/index.js
+++ b/generators/middleware/index.js
@@ -95,4 +95,8 @@ module.exports = class MiddlewareGenerator extends Generator {
       mainFile, context
     );
   }
+  
+  end () {
+    this._runLintIfAvailable();
+  }
 };

--- a/generators/service/index.js
+++ b/generators/service/index.js
@@ -241,4 +241,8 @@ module.exports = class ServiceGenerator extends Generator {
       }
     }
   }
+  
+  end () {
+    this._runLintIfAvailable();
+  }
 };

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -76,4 +76,8 @@ module.exports = class UpgradeGenerator extends Generator {
       save: true
     });
   }
+  
+  end () {
+    this._runLintIfAvailable();
+  }
 };

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -86,6 +86,21 @@ module.exports = class BaseGenerator extends Generator {
   templatePath (...paths) {
     return super.templatePath(this.srcType, ...paths);
   }
+  
+  _runLintIfAvailable() {
+    if (this.isTypescript) return;
+  
+    const packager = this.pkg.engines && this.pkg.engines.yarn ? 'yarn' : 'npm';
+    const existingDevDependencies = this.pkg['devDependencies'] || {};
+    
+    if (existingDevDependencies['eslint']) {
+      if (packager === 'yarn') {
+        this.spawnCommand(packager, ['run', 'lint', '--fix']);
+      } else {
+        this.spawnCommand(packager, ['run', 'lint', '--', '--fix']);
+      }
+    }
+  }
 
   _packagerInstall(deps, options) {
     const packager = this.pkg.engines && this.pkg.engines.yarn ?


### PR DESCRIPTION
Dear Maintainers,

I am proposing to merge the contents of this Pull Request.
This adds the option to edit the default eslintrc after selecting `eslint` as style enforcement option, while using the `generate app` command.

To make the generators compatible with a customized .eslintrc, I added a _runLintIfAvailable method to the BaseGenerator class, which checks for lang, packager and linter and then lints if possible.

Every generator is now calling this method in its `end()` hook, to make sure the generated files follow the enforced style declared in the custom .eslintrc.
This actually also fixes the issue that generators did not respond to a custom .eslintrc before.

Thank you.