### PR TITLE
Remove unnecessary @types/helmet dependency

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -256,7 +256,6 @@ module.exports = class AppGenerator extends Generator {
       this.devDependencies = this.devDependencies.concat([
         '@types/compression',
         '@types/cors',
-        '@types/helmet',
         '@types/serve-favicon',
         'shx',
         'ts-node-dev',


### PR DESCRIPTION
Helmet does not need types anymore. The package is deprecated see https://www.npmjs.com/package/@types/helmet.

<img width="977" alt="Bildschirmfoto 2020-12-13 um 20 07 51" src="https://user-images.githubusercontent.com/30391176/102021257-e27dc900-3d7e-11eb-96a4-544e05705662.png">

This change will also remove the warning when using ```feathers g app```.
