### PR TITLE
fix error on new mongodb connection

### DIFF
--- a/generators/connection/templates/js/mongodb.js
+++ b/generators/connection/templates/js/mongodb.js
@@ -3,7 +3,7 @@ const MongoClient = require('mongodb').MongoClient;
 module.exports = function (app) {
   const connection = app.get('mongodb');
   const database = connection.substr(connection.lastIndexOf('/') + 1);
-  const mongoClient = MongoClient.connect(connection, { useNewUrlParser: true })
+  const mongoClient = MongoClient.connect(connection, { useNewUrlParser: true, useUnifiedTopology: true })
     .then(client => client.db(database));
 
   app.set('mongoClient', mongoClient);

--- a/generators/connection/templates/ts/mongodb.ts
+++ b/generators/connection/templates/ts/mongodb.ts
@@ -4,7 +4,7 @@ import { Application } from './declarations';
 export default function (app: Application): void {
   const connection = app.get('mongodb');
   const database = connection.substr(connection.lastIndexOf('/') + 1);
-  const mongoClient = MongoClient.connect(connection, { useNewUrlParser: true })
+  const mongoClient = MongoClient.connect(connection, { useNewUrlParser: true, useUnifiedTopology: true })
     .then(client => client.db(database));
 
   app.set('mongoClient', mongoClient);


### PR DESCRIPTION
`
(node:2156) [MONGODB DRIVER] Warning: Current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
`