### PR TITLE
Improve type-safety of generated hooks object.

### DIFF
--- a/generators/service/templates/ts/hooks.ts
+++ b/generators/service/templates/ts/hooks.ts
@@ -1,3 +1,4 @@
+import { HooksObject } from '@feathersjs/feathers';
 <% if (requiresAuth) { %>import * as authentication from '@feathersjs/authentication';
 // Don't remove this comment. It's needed to format import lines nicely.
 
@@ -33,4 +34,4 @@ export default {
     patch: [],
     remove: []
   }
-};
+} as HooksObject;


### PR DESCRIPTION
This pull request adds a type definition to the exported hooks created by the generator.

This way, type errors will appear directly in the hooks file instead of in whichever services that tries to use the hooks. It also has the added benefit of enabling better type-hinting for the hooks. 🙌