### PR TITLE
Make `service` available to service-level Jest tests.

### DIFF
--- a/generators/service/templates/js/test.jest.js
+++ b/generators/service/templates/js/test.jest.js
@@ -1,8 +1,9 @@
 const app = require('<%= relativeRoot %><%= libDirectory %>/app');
 
 describe('\'<%= name %>\' service', () => {
+  const service = app.service('<%= path %>');
+  
   it('registered the service', () => {
-    const service = app.service('<%= path %>');
     expect(service).toBeTruthy();
   });
 });

--- a/generators/service/templates/ts/test.jest.ts
+++ b/generators/service/templates/ts/test.jest.ts
@@ -1,8 +1,9 @@
 import app from '<%= relativeRoot %><%= libDirectory %>/app';
 
 describe('\'<%= name %>\' service', () => {
+  const service = app.service('<%= path %>');
+  
   it('registered the service', () => {
-    const service = app.service('<%= path %>');
     expect(service).toBeTruthy();
   });
 });


### PR DESCRIPTION
Just a small change that makes the `service` const available to all service-level tests, instead of only using it in the "registered the service". test.

I find this approach particularly useful as I don't have to constantly type out `app.service(<name>)`  for each test that uses the service directly. Not sure what your opinion is on this - if you feel it's a bad pattern to follow, please do feel free to just close the PR. 👍