### PR TITLE
Fix deprecation warning

### DIFF
--- a/generators/connection/templates/js/mongoose.js
+++ b/generators/connection/templates/js/mongoose.js
@@ -4,7 +4,7 @@ const logger = require('./logger');
 module.exports = function (app) {
   mongoose.connect(
     app.get('mongodb'),
-    { useCreateIndex: true, useNewUrlParser: true }
+    { useCreateIndex: true, useNewUrlParser: true, useUnifiedTopology: true }
   ).catch(err => {
     logger.error(err);
     process.exit(1);

--- a/generators/connection/templates/ts/mongoose.ts
+++ b/generators/connection/templates/ts/mongoose.ts
@@ -5,7 +5,7 @@ import logger from './logger';
 export default function (app: Application): void {
   mongoose.connect(
     app.get('mongodb'),
-    { useCreateIndex: true, useNewUrlParser: true }
+    { useCreateIndex: true, useNewUrlParser: true, useUnifiedTopology: true }
   ).catch(err => {
     logger.error(err);
     process.exit(1);


### PR DESCRIPTION
```
[INFO] 16:35:47 ts-node-dev ver. 1.1.8 (using ts-node ver. 9.1.1, typescript ver. 4.4.4)
info: Feathers application started on http://localhost:3030
(node:33692) [MONGODB DRIVER] Warning: Current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
(Use `node --trace-warnings ...` to show where the warning was created)
```

**To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.**