### PR TITLE
Fix TypeScript hook export to continue working with codemods

### DIFF
--- a/generators/service/templates/ts/hooks.ts
+++ b/generators/service/templates/ts/hooks.ts
@@ -34,4 +34,4 @@ export default {
     patch: [],
     remove: []
   }
-} as HooksObject;
+};


### PR DESCRIPTION
https://github.com/feathersjs/generator-feathers/pull/638 was a good change but breaks the codemods that are currently used.

Closes https://github.com/feathersjs/feathers/issues/2503