### PR TITLE
change sequelize import hook path

### DIFF
--- a/generators/service/templates/ts/model/sequelize-user.ts
+++ b/generators/service/templates/ts/model/sequelize-user.ts
@@ -2,7 +2,7 @@
 // for more of what you can do here.
 import { Sequelize, DataTypes, Model } from 'sequelize';
 import { Application } from '../declarations';
-import { HookReturn } from 'sequelize/types/lib/hooks';
+import { HookReturn } from 'sequelize/types/hooks';
 
 export default function (app: Application): typeof Model {
   const sequelizeClient: Sequelize = app.get('sequelizeClient');

--- a/generators/service/templates/ts/model/sequelize.ts
+++ b/generators/service/templates/ts/model/sequelize.ts
@@ -2,7 +2,7 @@
 // for more of what you can do here.
 import { Sequelize, DataTypes, Model } from 'sequelize';
 import { Application } from '../declarations';
-import { HookReturn } from 'sequelize/types/lib/hooks';
+import { HookReturn } from 'sequelize/types/hooks';
 
 export default function (app: Application): typeof Model {
   const sequelizeClient: Sequelize = app.get('sequelizeClient');


### PR DESCRIPTION
fixs SequelizeHooks import error when generating with typescript and sequelize

see here for example of error and fix:

https://stackoverflow.com/questions/71090152/cannot-find-module-sequelize-types-lib-hooks-or-its-corresponding-type-declara